### PR TITLE
Fix: 括弧を含む式の構文解析が失敗するのを修正

### DIFF
--- a/src/shol.lalrpop
+++ b/src/shol.lalrpop
@@ -69,19 +69,7 @@ Rule: ast::RuleAST = {
 
 Expr: Box<ast::ExprAST> = {
     #[precedence(level="1")]
-    "int" => {
-        Box::new(ast::ExprAST::Number(<>))
-    },
-    "identf" => {
-        Box::new(ast::ExprAST::Str(<>))
-    },
-    "str" => {
-        Box::new(ast::ExprAST::Str(<>))
-    },
-    "$" <name:"identf"?> => {
-        Box::new(ast::ExprAST::Capture(name.unwrap_or_default()))
-    },
-    "(" <inner:Expr> ")" => inner,
+    <Factor>,
     <Expr> "space",
 
     #[precedence(level="2")] #[assoc(side="left")]
@@ -122,6 +110,22 @@ Expr: Box<ast::ExprAST> = {
     <lhs:Expr> ">=" sp? <rhs:Expr> => {
         Box::new(ast::ExprAST::BinaryOp(lhs, ast::Opcode::Ge, rhs))
     },
+}
+
+Factor: Box<ast::ExprAST> = {
+    "int" => {
+        Box::new(ast::ExprAST::Number(<>))
+    },
+    "identf" => {
+        Box::new(ast::ExprAST::Str(<>))
+    },
+    "str" => {
+        Box::new(ast::ExprAST::Str(<>))
+    },
+    "$" <name:"identf"?> => {
+        Box::new(ast::ExprAST::Capture(name.unwrap_or_default()))
+    },
+    "(" <inner:Expr> ")" => inner,
 }
 
 // MARK: ヘルパー非終端記号


### PR DESCRIPTION
close #2

文法ファイルを修正しました。

↓ 修正後 `. $a, ($b+4)=5, $c # ($a + 4 + $b) + ($b - 5)` で得られた AST

![0F89C43E-3666-4E68-A6CD-FD6CAA3CC1D3_1_102_o](https://github.com/user-attachments/assets/baf67f6d-30c6-445b-8598-7f369c302264)
