### PR TITLE
Refactor: space トークンを削除

### DIFF
--- a/src/shol.lalrpop
+++ b/src/shol.lalrpop
@@ -6,18 +6,18 @@ grammar;
 // MARK: 構文
 
 pub Program: Vec<ast::StatementAST> = {
-    nl? <stmts:Statement*> => stmts
+    "nl"* <stmts:Statement*> => stmts
 };
 
 Statement: ast::StatementAST = {
-    "*" <name:"identf"> nl <resources:Resource*> <prules:RuleSet*> => {
+    "*" <name:"identf"> "nl"+ <resources:Resource*> <prules:RuleSet*> => {
         ast::StatementAST::ColonyDecl {
             name,
             resources,
             rules: prules,
         }
     },
-    "%" <name:"identf"> nl <resources:Resource*> <prules:RuleSet*> => {
+    "%" <name:"identf"> "nl"+ <resources:Resource*> <prules:RuleSet*> => {
         ast::StatementAST::ColonyExtension {
             name,
             resources,
@@ -27,9 +27,9 @@ Statement: ast::StatementAST = {
 }
 
 Resource: ast::ExprAST = {
-    <"int"> nl => ast::ExprAST::Number(<>),
-    <"identf"> nl => ast::ExprAST::Str(<>),
-    <"str"> nl => ast::ExprAST::Str(<>),
+    <"int"> "nl"+ => ast::ExprAST::Number(<>),
+    <"identf"> "nl"+ => ast::ExprAST::Str(<>),
+    <"str"> "nl"+ => ast::ExprAST::Str(<>),
 }
 
 RuleSet: ast::RuleSetAST = {
@@ -41,22 +41,22 @@ RuleSet: ast::RuleSetAST = {
 }
 
 FirstRule: ast::RuleAST = {
-    "." sp <Rule> "newline" spnl*
+    "." <Rule> "nl"+
 }
 
 ParallelRule: ast::RuleAST = {
-    "|" sp <Rule> "newline" spnl*
+    "|" <Rule> "nl"+
 }
 
 Rule: ast::RuleAST = {
-    <condition:CommaListing<Expr>> "#" <dest:"identf"?> sp <output:CommaListing<Expr>> => {
+    <condition:CommaListing<Expr>> <dest:"#xx"> <output:CommaListing<Expr>> => {
         ast::RuleAST {
             conditions: condition.into_iter().map(|o| *o).collect(),
             destination: dest,
             outputs: output.into_iter().map(|o| *o).collect(),
         }
     },
-    <condition:CommaListing<Expr>> "#" <dest:"identf"?> sp? => {
+    <condition:CommaListing<Expr>> <dest:"#xx"> => {
         ast::RuleAST {
             conditions: condition.into_iter().map(|o| *o).collect(),
             destination: dest,
@@ -70,44 +70,43 @@ Rule: ast::RuleAST = {
 Expr: Box<ast::ExprAST> = {
     #[precedence(level="1")]
     <Factor>,
-    <Expr> "space",
 
     #[precedence(level="2")] #[assoc(side="left")]
-    <lhs:Expr> "*" sp? <rhs:Expr> => {
+    <lhs:Expr> "*" <rhs:Expr> => {
         Box::new(ast::ExprAST::BinaryOp(lhs, ast::Opcode::Mul, rhs))
     },
-    <lhs:Expr> "/" sp? <rhs:Expr> => {
+    <lhs:Expr> "/" <rhs:Expr> => {
         Box::new(ast::ExprAST::BinaryOp(lhs, ast::Opcode::Div, rhs))
     },
-    <lhs:Expr> "%" sp? <rhs:Expr> => {
+    <lhs:Expr> "%" <rhs:Expr> => {
         Box::new(ast::ExprAST::BinaryOp(lhs, ast::Opcode::Mod, rhs))
     },
 
     #[precedence(level="3")] #[assoc(side="left")]
-    <lhs:Expr> "+" sp? <rhs:Expr> => {
+    <lhs:Expr> "+" <rhs:Expr> => {
         Box::new(ast::ExprAST::BinaryOp(lhs, ast::Opcode::Add, rhs))
     },
-    <lhs:Expr> "-" sp? <rhs:Expr> => {
+    <lhs:Expr> "-" <rhs:Expr> => {
         Box::new(ast::ExprAST::BinaryOp(lhs, ast::Opcode::Sub, rhs))
     },
 
     #[precedence(level="4")] #[assoc(side="left")]
-    <lhs:Expr> "=" sp? <rhs:Expr> => {
+    <lhs:Expr> "=" <rhs:Expr> => {
         Box::new(ast::ExprAST::BinaryOp(lhs, ast::Opcode::Eq, rhs))
     },
-    <lhs:Expr> "!=" sp? <rhs:Expr> => {
+    <lhs:Expr> "!=" <rhs:Expr> => {
         Box::new(ast::ExprAST::BinaryOp(lhs, ast::Opcode::Ne, rhs))
     },
-    <lhs:Expr> "<" sp? <rhs:Expr> => {
+    <lhs:Expr> "<" <rhs:Expr> => {
         Box::new(ast::ExprAST::BinaryOp(lhs, ast::Opcode::Lt, rhs))
     },
-    <lhs:Expr> ">" sp? <rhs:Expr> => {
+    <lhs:Expr> ">" <rhs:Expr> => {
         Box::new(ast::ExprAST::BinaryOp(lhs, ast::Opcode::Gt, rhs))
     },
-    <lhs:Expr> "<=" sp? <rhs:Expr> => {
+    <lhs:Expr> "<=" <rhs:Expr> => {
         Box::new(ast::ExprAST::BinaryOp(lhs, ast::Opcode::Le, rhs))
     },
-    <lhs:Expr> ">=" sp? <rhs:Expr> => {
+    <lhs:Expr> ">=" <rhs:Expr> => {
         Box::new(ast::ExprAST::BinaryOp(lhs, ast::Opcode::Ge, rhs))
     },
 }
@@ -122,8 +121,8 @@ Factor: Box<ast::ExprAST> = {
     "str" => {
         Box::new(ast::ExprAST::Str(<>))
     },
-    "$" <name:"identf"?> => {
-        Box::new(ast::ExprAST::Capture(name.unwrap_or_default()))
+    "$xx" => {
+        Box::new(ast::ExprAST::Capture(<>))
     },
     "(" <inner:Expr> ")" => inner,
 }
@@ -133,19 +132,11 @@ Factor: Box<ast::ExprAST> = {
 // カンマ区切りで 1 つ以上列挙する構文
 CommaListing<T>: Vec<T> = {
     T => vec![<>],
-    <mut v:CommaListing<T>> "," sp? <e:T> => {
+    <mut v:CommaListing<T>> "," <e:T> => {
         v.push(e);
         v
     }
 }
-
-// sp?  space*
-// sp    + 1 つ以上のスペースを含む
-// nl?  (space|newline)*
-// nl    + 1 つ以上の改行を含む
-sp: () = "space"+;
-nl: () = sp? "newline" spnl*;
-spnl: () = { "space", "newline" }
 
 // MARK: トークン (終端記号)
 
@@ -173,9 +164,8 @@ extern {
         "." => Token::Dot,
         "|" => Token::Pipe,
         "," => Token::Comma,
-        "#" => Token::Hash,
-        "$" => Token::Dollar,
-        "space" => Token::Space(<String>),
-        "newline" => Token::NewLine(<String>),
+        "#xx" => Token::Destination(<Option<String>>),
+        "$xx" => Token::Capture(<String>),
+        "nl" => Token::NewLine(<String>),
     }
 }

--- a/src/tokens.rs
+++ b/src/tokens.rs
@@ -44,6 +44,7 @@ fn decode_string(input: &str) -> String {
 
 #[derive(Logos, Clone, Debug, PartialEq)]
 #[logos(error = LexicalError)]
+#[logos(skip r"[ \t]+")]
 pub enum Token {
     // 数値と識別子
     #[regex(r"(\p{XID_Start}|_)\p{XID_Continue}*", |lex| lex.slice().to_string())]
@@ -88,15 +89,15 @@ pub enum Token {
     Pipe,
     #[token(",")]
     Comma,
-    #[token("#")]
-    Hash,
-    #[token("$")]
-    Dollar,
+    #[regex(r"#((\p{XID_Start}|_)\p{XID_Continue}*)?", // #a -> Some("a"), # -> None
+        |lex| lex.slice().strip_prefix('#').filter(|s| !s.is_empty()).map(|s| s.to_string()))]
+    Destination(Option<String>),
+    #[regex(r"\$((\p{XID_Start}|_)\p{XID_Continue}*)?", // $a -> "a", $ -> ""
+        |lex| lex.slice().strip_prefix('$').unwrap().to_string())]
+    Capture(String),
 
-    // スペースや改行
-    #[regex(r"[ \t]", |lex| lex.slice().to_string())]
-    Space(String),
-    #[regex(r"[\r\n]", |lex| lex.slice().to_string())]
+    // 改行
+    #[regex(r"\n|\r\n|\r|\f", |lex| lex.slice().to_string())]
     NewLine(String),
 }
 


### PR DESCRIPTION
`shol.lalrpop` 上でノイズになっていた space トークンについて、恐らく消しても問題ないだろうと判断して削除しました。

この変更で、空白文字は字句解析でスキップ (トークン化せずに無視すること) の対象になります。

文法ファイルの保守性と可読性を改善できたと思います。