### PR TITLE
Feature: ConditionAST, OutputAST とそのメタデータの作成

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -30,10 +30,17 @@ impl fmt::Debug for StatementAST {
     }
 }
 
-// MARK: RuleSetAST
+// MARK: RuleSetAST, RuleAST
 
 pub struct RuleSetAST {
     pub rules: Vec<RuleAST>,
+}
+
+pub struct RuleAST {
+    pub conditions: Vec<ConditionAST>,
+    pub destination: Option<String>,
+    pub outputs: Vec<OutputAST>,
+    pub meta: Option<semantics::RuleASTMeta>,
 }
 
 impl fmt::Debug for RuleSetAST {
@@ -42,23 +49,42 @@ impl fmt::Debug for RuleSetAST {
     }
 }
 
-// MARK: RuleAST
-
-pub struct RuleAST {
-    pub conditions: Vec<ExprAST>,
-    pub destination: Option<String>,
-    pub outputs: Vec<ExprAST>,
-    pub meta: Option<semantics::RuleASTMeta>,
-}
-
 impl fmt::Debug for RuleAST {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{{\"Rule\":{{\".conditions\":{:?}{},\".outputs\":{:?}{}}}}}",
+        write!(f, "{{\"Rule\":{{\".conditions\":{:?}{},\".outputs\":{:?}}}}}",
             self.conditions,
             self.destination.as_ref().map_or(String::new(), |d| format!(",\".destination\":{:?}", d)),
             self.outputs,
-            self.meta.as_ref().map_or(String::new(), |m| format!(",\".meta\":{:?}", m)),
         )
+    }
+}
+
+// MARK: ConditionAST, OutputAST
+
+pub struct ConditionAST {
+    pub expr: ExprAST,
+    pub meta: Option<semantics::ConditionASTMeta>,
+}
+
+pub struct OutputAST {
+    pub expr: ExprAST,
+    pub meta: Option<semantics::OutputASTMeta>,
+}
+
+impl fmt::Debug for ConditionAST {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "{{\"Condition{}\":{{\".expr\":{:?}}}}}",
+            self.meta.as_ref().map(|m| format!(":{:?}", m.kind)).unwrap_or_default(),
+            self.expr
+        )
+    }
+}
+
+impl fmt::Debug for OutputAST {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{{\"Output\":{{\".expr\":{:?}}}}}", self.expr)
     }
 }
 

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -84,7 +84,12 @@ impl fmt::Debug for ConditionAST {
 
 impl fmt::Debug for OutputAST {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{{\"Output\":{{\".expr\":{:?}}}}}", self.expr)
+        write!(
+            f,
+            "{{\"Output({})\":{{\".expr\":{:?}}}}}",
+            self.meta.as_ref().map(|m| format!("{}", m.associated_captures.join(","))).unwrap_or_default(),
+            self.expr
+        )
     }
 }
 

--- a/src/semantics.rs
+++ b/src/semantics.rs
@@ -656,8 +656,21 @@ fn validate_inference(captures: &HashMap<String, TypeHint>, outputs: &Vec<ast::O
     }
 
     outputs.iter().for_each(|output| {
+        // captures から output に登場するキャプチャだけを取り出す
+        let associated_captures = &output.meta.as_ref().unwrap().associated_captures;
+        let captures: HashMap<String, TypeHint> = associated_captures.iter()
+            .map(|name| (name.clone(), captures[name].clone()))
+            .collect();
+
+        // 再帰関数の呼び出し
         let captures_type = HashMap::new();
-        if let Err(detail) = _validate_inference(captures, &captures_type, output) {
+        let result = _validate_inference(
+            &captures,
+            &captures_type,
+            output,
+        );
+
+        if let Err(detail) = result {
             // エラーメッセージの作成
             let mut err_msg = String::new();
             err_msg.push_str(&format!("出力式にキャプチャ間の型制約関係が含まれます:"));

--- a/src/shol.lalrpop
+++ b/src/shol.lalrpop
@@ -49,22 +49,30 @@ ParallelRule: ast::RuleAST = {
 }
 
 Rule: ast::RuleAST = {
-    <condition:CommaListing<Expr>> "#" <dest:"identf"?> sp <output:CommaListing<Expr>> => {
+    <conds:CommaListing<Condition>> "#" <dest:"identf"?> sp <outs:CommaListing<Output>> => {
         ast::RuleAST {
-            conditions: condition.into_iter().map(|o| *o).collect(),
+            conditions: conds,
             destination: dest,
-            outputs: output.into_iter().map(|o| *o).collect(),
+            outputs: outs,
             meta: None,
         }
     },
-    <condition:CommaListing<Expr>> "#" <dest:"identf"?> sp? => {
+    <conds:CommaListing<Condition>> "#" <dest:"identf"?> sp? => {
         ast::RuleAST {
-            conditions: condition.into_iter().map(|o| *o).collect(),
+            conditions: conds,
             destination: dest,
             outputs: vec![],
             meta: None,
         }
     }
+}
+
+Condition: ast::ConditionAST = {
+    <Expr> => ast::ConditionAST { expr: *<>, meta: None },
+}
+
+Output: ast::OutputAST = {
+    <Expr> => ast::OutputAST { expr: *<>, meta: None },
 }
 
 // MARK: 式


### PR DESCRIPTION
コード生成のフェーズに備え、以下の変更を行いました。

### AST 構造の変更点

RuleAST は ExprAST を直接持つのではなく、ConditionAST と OutputAST を中継します。

```rs
pub struct RuleAST {
    pub conditions: Vec<ConditionAST>,  // 型変更
    pub destination: Option<String>,
    pub outputs: Vec<OutputAST>,  // 型変更
    pub meta: Option<semantics::RuleASTMeta>,
}

// 新規追加
pub struct ConditionAST {
    pub expr: ExprAST,
    pub meta: Option<semantics::ConditionASTMeta>,
}
pub struct OutputAST {
    pub expr: ExprAST,
    pub meta: Option<semantics::OutputASTMeta>,
}
```

### メタデータの変更点

RuleASTMeta が持っていた `condition_kinds` を ConditionASTMeta に持たせました。

出力式に新規メタデータ `associated_captures` を持たせました。

```rs
pub struct RuleASTMeta {
    pub captures: HashMap<String, TypeHint>,
    // pub condition_kinds: Vec<ConditionKind>, (削除)
}

// 新規追加
pub struct ConditionASTMeta {
    pub kind: ConditionKind,
}
pub struct OutputASTMeta {
    // 出力式に含まれるキャプチャのリスト
    pub associated_captures: Vec<String>,
}
```