### PR TITLE
Feature: 1 つの規則で複数の出力先をサポート

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -38,7 +38,6 @@ pub struct RuleSetAST {
 
 pub struct RuleAST {
     pub conditions: Vec<ConditionAST>,
-    pub destination: Option<String>,
     pub outputs: Vec<OutputAST>,
     pub meta: Option<semantics::RuleASTMeta>,
 }
@@ -51,9 +50,8 @@ impl fmt::Debug for RuleSetAST {
 
 impl fmt::Debug for RuleAST {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{{\"Rule\":{{\".conditions\":{:?}{},\".outputs\":{:?}}}}}",
+        write!(f, "{{\"Rule\":{{\".conditions\":{:?},\".outputs\":{:?}}}}}",
             self.conditions,
-            self.destination.as_ref().map_or(String::new(), |d| format!(",\".destination\":{:?}", d)),
             self.outputs,
         )
     }
@@ -68,6 +66,7 @@ pub struct ConditionAST {
 
 pub struct OutputAST {
     pub expr: ExprAST,
+    pub destination: Option<String>,
     pub meta: Option<semantics::OutputASTMeta>,
 }
 
@@ -86,8 +85,9 @@ impl fmt::Debug for OutputAST {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
-            "{{\"Output({})\":{{\".expr\":{:?}}}}}",
+            "{{\"Output({}){}\":{{\".expr\":{:?}}}}}",
             self.meta.as_ref().map(|m| format!("{}", m.associated_captures.join(","))).unwrap_or_default(),
+            self.destination.as_ref().map_or("#".to_string(), |d| format!("#{}", d)),
             self.expr
         )
     }

--- a/src/shol.lalrpop
+++ b/src/shol.lalrpop
@@ -49,30 +49,44 @@ ParallelRule: ast::RuleAST = {
 }
 
 Rule: ast::RuleAST = {
-    <conds:CommaListing<Condition>> <dest:"#xx"> <outs:CommaListing<Output>> => {
+    <conds:CommaListing<Condition>> <outs:Outputs> => {
         ast::RuleAST {
             conditions: conds,
-            destination: dest,
             outputs: outs,
             meta: None,
         }
     },
-    <conds:CommaListing<Condition>> <dest:"#xx"> => {
-        ast::RuleAST {
-            conditions: conds,
-            destination: dest,
-            outputs: vec![],
-            meta: None,
-        }
-    }
 }
 
 Condition: ast::ConditionAST = {
     <Expr> => ast::ConditionAST { expr: *<>, meta: None },
 }
 
-Output: ast::OutputAST = {
-    <Expr> => ast::OutputAST { expr: *<>, meta: None },
+Outputs: Vec<ast::OutputAST> = {
+    <OutputsEndsWithDest> => <>.0,
+    <OutputsEndsWithExpr> => <>.0,
+}
+OutputsEndsWithDest: (Vec<ast::OutputAST>, Option<String>) = {
+    <dest:"#xx"> => (vec![], dest),
+    <outs:Outputs> <dest:"#xx"> => (outs, dest),
+}
+OutputsEndsWithExpr: (Vec<ast::OutputAST>, Option<String>) = {
+    <mut vd:OutputsEndsWithDest> <expr:Expr> => {
+        vd.0.push(ast::OutputAST {
+            expr: *expr,
+            destination: vd.1.clone(),
+            meta: None,
+        });
+        vd
+    },
+    <mut vd:OutputsEndsWithExpr> "," <expr:Expr> => {
+        vd.0.push(ast::OutputAST {
+            expr: *expr,
+            destination: vd.1.clone(),
+            meta: None,
+        });
+        vd
+    },
 }
 
 // MARK: 式


### PR DESCRIPTION
次のような構文をサポートしました。

```shol
. $a, $b # $a, $b #print $a+$b
```
→ `$a`, `$b` が自分のリソースに、`$a+$b` が `print` に出力される。

生成規則は少しトリッキーな構造になりました。

```bnf
<Outputs>
  ::= <OutputsEndsWithDest> | <OutputsEndsWithExpr>
<OutputsEndsWithDest>
  ::= "#xx" | <Outputs> "#xx"
<OutputsEndsWithExpr>
  ::= <OutputsEndsWithDest> <式> | <OutputsEndsWithExpr> "," <式>
```

この変更で RuleAST ではなく OutputAST が出力先の情報を持つようになります。