### PR TITLE
Feature: bool 型のリテラル `true`, `false` を追加

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -98,6 +98,7 @@ impl fmt::Debug for OutputAST {
 pub enum ExprAST {
     Number(i32),
     Str(String),
+    Bool(bool),
     Capture(String),
     BinaryOp(Box<ExprAST>, Opcode, Box<ExprAST>),
 }
@@ -109,6 +110,8 @@ impl fmt::Debug for ExprAST {
                 write!(f, "{{\"Number({})\":{{\"_\":{{}}}}}}", n),
             ExprAST::Str(s) =>
                 write!(f, "{{\"Str({})\":{{\"_\":{{}}}}}}", urlencode(s)),
+            ExprAST::Bool(b) =>
+                write!(f, "{{\"Bool({})\":{{\"_\":{{}}}}}}", b),
             ExprAST::Capture(s) =>
                 write!(f, "{{\"Capture({})\":{{\"_\":{{}}}}}}", s),
             ExprAST::BinaryOp(lhs, op, rhs) =>

--- a/src/code_generator.rs
+++ b/src/code_generator.rs
@@ -755,6 +755,10 @@ fn generate_expr(
             write!(f, "{:?}.to_owned()", s)?;
             result_type = Type::String;
         },
+        ast::ExprAST::Bool(b) => {
+            write!(f, "{}", b)?;
+            result_type = Type::Bool;
+        },
         ast::ExprAST::Capture(name) => {
             return generate_capture(f, name);
         },

--- a/src/preprocessor.rs
+++ b/src/preprocessor.rs
@@ -19,10 +19,14 @@ fn append_trailing_new_line(program: &str) -> String {
 /// ダブルクォートが省略された文字列リソース行をダブルクォートで囲む
 fn add_double_quote(program: &str) -> String {
     // 以下で始まる行はダブルクォートで囲まない
-    let excluding_token = vec![
+    let excluding1 = vec![
         r"\+", r"\-", r"\*", r"\/", r"\%",
         r"\.", r"\|", "\"",
         r"[0-9]",
+    ];
+    // 以下に一致する行はダブルクォートで囲まない
+    let excluding2 = vec![
+        "true", "false",
     ];
 
     // 行全体にマッチするパターン: lsp, content, rsp に分割
@@ -30,7 +34,8 @@ fn add_double_quote(program: &str) -> String {
     let line_re = Regex::new(line_pattern).unwrap();
 
     // content がこれにマッチした場合は除外するパターン
-    let exclude_pattern = format!(r"^(?:{})", excluding_token.join("|"));
+    let exclude_pattern = format!(r"^(?:{})|^(?:{})$",
+        excluding1.join("|"), excluding2.join("|"));
     let exclude_re = Regex::new(&exclude_pattern).unwrap();
 
     // 各行をチェック

--- a/src/semantics.rs
+++ b/src/semantics.rs
@@ -125,6 +125,7 @@ fn type_validate_expr<'a>(expr: &'a ast::ExprAST, captures: &HashMap<String, Typ
     match expr {
         ast::ExprAST::Number(_) => Ok(Type::Int),
         ast::ExprAST::Str(_) => Ok(Type::String),
+        ast::ExprAST::Bool(_) => Ok(Type::Bool),
         ast::ExprAST::Capture(name) => Ok(captures.get(name).unwrap().clone()),
         ast::ExprAST::BinaryOp(lhs, opcode, rhs) => {
             let lhs_type = type_validate_expr(lhs, captures)?;
@@ -209,8 +210,7 @@ fn analyze_output(outputs: &mut Vec<ast::OutputAST>, captures: &mut HashMap<Stri
     // 出力式に登場するキャプチャを調べる
     fn collect_captures(expr: &ast::ExprAST, captures: &mut Vec<String>) {
         match expr {
-            ast::ExprAST::Number(_) => (),
-            ast::ExprAST::Str(_) => (),
+            ast::ExprAST::Number(_)|ast::ExprAST::Str(_)|ast::ExprAST::Bool(_) => (),
             ast::ExprAST::Capture(name) =>
                 if !captures.contains(name) { captures.push(name.clone()); },
             ast::ExprAST::BinaryOp(lhs, _, rhs) => {
@@ -244,6 +244,7 @@ fn condition_kind(expr: &ast::ExprAST) -> ConditionKind {
     match expr {
         ast::ExprAST::Number(_) => ConditionKind::Equal(Type::Int),
         ast::ExprAST::Str(_) => ConditionKind::Equal(Type::String),
+        ast::ExprAST::Bool(_) => ConditionKind::Equal(Type::Bool),
         ast::ExprAST::Capture(name) => ConditionKind::Capture(name.clone()),
         ast::ExprAST::BinaryOp(lhs, opcode, rhs) => {
             // 左辺と右辺の条件式種別を取得
@@ -436,6 +437,7 @@ fn analyze_output_ast(
         // 定数式の型を返す
         ast::ExprAST::Number(_) => AOAResult::Constant(Type::Int),
         ast::ExprAST::Str(_) => AOAResult::Constant(Type::String),
+        ast::ExprAST::Bool(_) => AOAResult::Constant(Type::Bool),
 
         // capture_infers に登録されているインデックスを返す
         ast::ExprAST::Capture(name) => {
@@ -629,7 +631,8 @@ fn validate_inference(captures: &HashMap<String, TypeHint>, outputs: &Vec<ast::O
             // 型検証
             if let Err(ast) = type_validate_expr(&output.expr, captures_type) {
                 match ast {
-                    ast::ExprAST::Number(_) | ast::ExprAST::Str(_) | ast::ExprAST::Capture(_) => (),
+                    ast::ExprAST::Number(_)|ast::ExprAST::Str(_)|ast::ExprAST::Bool(_)|
+                    ast::ExprAST::Capture(_) => (),
                     ast::ExprAST::BinaryOp(lhs, opcode, rhs) => {
                         // エラーメッセージの作成
                         let mut err_msg = String::new();

--- a/src/shol.lalrpop
+++ b/src/shol.lalrpop
@@ -27,9 +27,7 @@ Statement: ast::StatementAST = {
 }
 
 Resource: ast::ExprAST = {
-    <"int"> "nl"+ => ast::ExprAST::Number(<>),
-    <"identf"> "nl"+ => ast::ExprAST::Str(<>),
-    <"str"> "nl"+ => ast::ExprAST::Str(<>),
+    <Literal> "nl"+,
 }
 
 RuleSet: ast::RuleSetAST = {
@@ -136,19 +134,22 @@ Expr: Box<ast::ExprAST> = {
 }
 
 Factor: Box<ast::ExprAST> = {
-    "int" => {
-        Box::new(ast::ExprAST::Number(<>))
-    },
-    "identf" => {
-        Box::new(ast::ExprAST::Str(<>))
-    },
-    "str" => {
-        Box::new(ast::ExprAST::Str(<>))
-    },
-    "$xx" => {
-        Box::new(ast::ExprAST::Capture(<>))
-    },
-    "(" <inner:Expr> ")" => inner,
+    <Literal> => Box::new(<>),
+    "$xx" => Box::new(ast::ExprAST::Capture(<>)),
+    "(" <Expr> ")",
+}
+
+Literal: ast::ExprAST = {
+    "int" =>
+        ast::ExprAST::Number(<>),
+    "identf" =>
+        ast::ExprAST::Str(<>),
+    "str" =>
+        ast::ExprAST::Str(<>),
+    "true" =>
+        ast::ExprAST::Bool(true),
+    "false" =>
+        ast::ExprAST::Bool(false),
 }
 
 // MARK: ヘルパー非終端記号
@@ -172,6 +173,8 @@ extern {
         "identf" => Token::Identifier(<String>),
         "int" => Token::IntegerLiteral(<i32>),
         "str" => Token::StringLiteral(<String>),
+        "true" => Token::True,
+        "false" => Token::False,
         "(" => Token::LParen,
         ")" => Token::RParen,
         "=" => Token::Equal,

--- a/src/tokens.rs
+++ b/src/tokens.rs
@@ -46,13 +46,17 @@ fn decode_string(input: &str) -> String {
 #[logos(error = LexicalError)]
 #[logos(skip r"[ \t]+")]
 pub enum Token {
-    // 数値と識別子
+    // 識別子とリテラル
     #[regex(r"(\p{XID_Start}|_)\p{XID_Continue}*", |lex| lex.slice().to_string())]
     Identifier(String),
     #[regex("0|[1-9][0-9]*", |lex| lex.slice().parse())]
     IntegerLiteral(i32),
     #[regex(r#""([^"\\\x00-\x1F]|\\.)*""#, |lex| decode_string(lex.slice()))]
     StringLiteral(String),
+    #[token("true")]
+    True,
+    #[token("false")]
+    False,
 
     // 式に使われる記号
     #[token("(")]


### PR DESCRIPTION
close #16

動作確認済み：
```
*nGen
 true      
. $=true # false, false=$
. $ #print "けも"+$

%print
```
→ `けもfalse, けもfalse`