### PR TITLE
Feature: 単項演算子 `-` を実装

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -100,6 +100,7 @@ pub enum ExprAST {
     Str(String),
     Bool(bool),
     Capture(String),
+    UnaryOp(UnaryOpcode, Box<ExprAST>),
     BinaryOp(Box<ExprAST>, Opcode, Box<ExprAST>),
 }
 
@@ -114,6 +115,8 @@ impl fmt::Debug for ExprAST {
                 write!(f, "{{\"Bool({})\":{{\"_\":{{}}}}}}", b),
             ExprAST::Capture(s) =>
                 write!(f, "{{\"Capture({})\":{{\"_\":{{}}}}}}", s),
+            ExprAST::UnaryOp(op, operand) =>
+                write!(f, "{{\"BinaryOp({:?})\":{:?}}}", op, operand),
             ExprAST::BinaryOp(lhs, op, rhs) =>
                 write!(f, "{{\"BinaryOp({:?})\":{{\".lhs\":{:?},\".rhs\":{:?}}}}}", op, lhs, rhs),
         }
@@ -121,6 +124,11 @@ impl fmt::Debug for ExprAST {
 }
 
 // MARK: Opcode
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UnaryOpcode {
+    Neg,
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Opcode {

--- a/src/shol.lalrpop
+++ b/src/shol.lalrpop
@@ -157,8 +157,9 @@ Literal: ast::ExprAST = {
 }
 
 SignedInt: i32 = {
-    "-" <n:"int"> => -n,
     <n:"int"> => n,
+    "-" <n:"int"> => -n,
+    <"intmin">,
 }
 
 // MARK: ヘルパー非終端記号
@@ -181,6 +182,7 @@ extern {
     enum Token {
         "identf" => Token::Identifier(<String>),
         "int" => Token::IntegerLiteral(<i32>),
+        "intmin" => Token::IntegerMin(<i32>),
         "str" => Token::StringLiteral(<String>),
         "true" => Token::True,
         "false" => Token::False,

--- a/src/shol.lalrpop
+++ b/src/shol.lalrpop
@@ -134,13 +134,17 @@ Expr: Box<ast::ExprAST> = {
 }
 
 Factor: Box<ast::ExprAST> = {
-    <Literal> => Box::new(<>),
+    #[precedence(level="1")]
     "$xx" => Box::new(ast::ExprAST::Capture(<>)),
     "(" <Expr> ")",
+    "-" <Factor> => Box::new(ast::ExprAST::UnaryOp(ast::UnaryOpcode::Neg, <>)),
+
+    #[precedence(level="2")]
+    <Literal> => Box::new(<>),
 }
 
 Literal: ast::ExprAST = {
-    "int" =>
+    <SignedInt> =>
         ast::ExprAST::Number(<>),
     "identf" =>
         ast::ExprAST::Str(<>),
@@ -150,6 +154,11 @@ Literal: ast::ExprAST = {
         ast::ExprAST::Bool(true),
     "false" =>
         ast::ExprAST::Bool(false),
+}
+
+SignedInt: i32 = {
+    "-" <n:"int"> => -n,
+    <n:"int"> => n,
 }
 
 // MARK: ヘルパー非終端記号

--- a/src/tokens.rs
+++ b/src/tokens.rs
@@ -51,6 +51,8 @@ pub enum Token {
     Identifier(String),
     #[regex("0|[1-9][0-9]*", |lex| lex.slice().parse())]
     IntegerLiteral(i32),
+    #[token("-2147483648", |_| -2147483648)] // - と 2147483648 を別トークンにするとオーバフローするため特別扱い
+    IntegerMin(i32),
     #[regex(r#""([^"\\\x00-\x1F]|\\.)*""#, |lex| decode_string(lex.slice()))]
     StringLiteral(String),
     #[token("true")]


### PR DESCRIPTION
close #14

初めての 単項演算子 導入 なのでちょっと差分多いです。

↓動作確認済み
```
*test
-42
. -(-$-30) = -3*4 # -$
. $ #print $

%print
```
→ `42`