### PR TITLE
Feature: 出力ファイル関係を調整, `-S` オプション実装

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,6 +119,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "errno"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
 name = "fixedbitset"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -138,6 +154,27 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "getopts"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14dbbfd5c71d70241ecf9e6f13737f7b5ce823821063188d7e46c41d371eebd5"
+dependencies = [
+ "unicode-width",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+ "windows-targets",
 ]
 
 [[package]]
@@ -228,6 +265,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db9c683daf087dc577b7506e9695b3d556a9f3849903fa28186283afd6809e9"
+
+[[package]]
 name = "lock_api"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -287,6 +330,12 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "once_cell"
+version = "1.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
 
 [[package]]
 name = "parking_lot"
@@ -399,6 +448,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
+name = "rustix"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dade4812df5c384711475be5fcd8c162555352945401aed22a35bffeab61f657"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -433,10 +495,12 @@ dependencies = [
 name = "shol"
 version = "0.1.0"
 dependencies = [
+ "getopts",
  "lalrpop",
  "lalrpop-util",
  "logos",
  "regex",
+ "tempfile",
 ]
 
 [[package]]
@@ -475,6 +539,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c317e0a526ee6120d8dabad239c8dadca62b24b6f168914bbbc8e2fb1f0e567"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "term"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -497,6 +575,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a210d160f08b701c8721ba1c726c11662f877ea6b7094007e1ca9a1041945034"
 
 [[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -516,6 +600,15 @@ checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",
+]
+
+[[package]]
+name = "wasi"
+version = "0.13.3+wasi-0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2"
+dependencies = [
+ "wit-bindgen-rt",
 ]
 
 [[package]]
@@ -608,3 +701,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
+dependencies = [
+ "bitflags",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,9 +4,11 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+getopts = "0.2.21"
 lalrpop-util = { version = "0.22.1", features = ["lexer"] }
 logos = "0.14"
 regex = "1.11.1"
+tempfile = "3.18.0"
 
 [build-dependencies]
 lalrpop = "0.22.1"

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,7 +19,11 @@ fn main() {
 
     // 出力ファイル名の設定
     let out_rs_file = format!("{}.rs", src_file.trim_end_matches(".shol"));
-    let out_exe_file = format!("{}.out", src_file.trim_end_matches(".shol"));
+    let exe_file = if cfg!(target_os = "windows") {
+        format!("{}.exe", src_file.trim_end_matches(".shol"))
+    } else {
+        src_file.trim_end_matches(".shol").to_string()
+    };
 
     // 入力ファイルの読み込み
     let program = std::fs::read_to_string(src_file)
@@ -57,7 +61,7 @@ fn main() {
     let status = std::process::Command::new("rustc")
         .arg(&out_rs_file)
         .arg("-o")
-        .arg(out_exe_file)
+        .arg(exe_file)
         .status()
         .expect("Failed to execute rustc");
     if !status.success() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use std::{env, io::Write};
+use std::{env, io::Write, fs::File, process::ExitCode};
 use lalrpop_util::lalrpop_mod;
 use getopts::Options;
 use tempfile::Builder;
@@ -11,18 +11,25 @@ pub mod semantics;
 pub mod code_generator;
 lalrpop_mod!(pub shol);
 
-/// コマンドライン引数をパースして得られる設定
 struct Config {
+    /// ソースファイル名
     src_file: String,
-    save_temps: bool,
-    out_rs_file: String,
-    out_shi_file: String,
+    /// 中間生成ファイル名
+    shi_file: Option<String>,
+    /// 中間生成ファイル名
+    rs_file: String,
+    /// 実行ファイル名
     exe_file: String,
 }
 
-fn main() {
+fn main() -> ExitCode {
+    // コマンドライン引数のパース
     let args: Vec<String> = env::args().collect();
     let config = parse_args(args);
+    if let Err(e) = config {
+        return e;
+    }
+    let config = config.unwrap();
 
     // 入力ファイルの読み込み
     let program = std::fs::read_to_string(&config.src_file)
@@ -31,8 +38,9 @@ fn main() {
     // プリプロセス
     println!("[*] Preprocessing...");
     let program = preprocessor::preprocess(&program);
-    if config.save_temps {
-        let mut out_file = std::fs::File::create(&config.out_shi_file)
+
+    if let Some(path) = config.shi_file {
+        let mut out_file = File::create(&path)
             .expect("Failed to create output file");
         out_file.write_all(program.as_bytes())
             .expect("Failed to write program to file");
@@ -52,7 +60,7 @@ fn main() {
     println!("{{\"AST\":{:?}}}", ast);
 
     // 出力ファイルを開く
-    let mut out_file = std::fs::File::create(&config.out_rs_file)
+    let mut out_file = File::create(&config.rs_file)
         .expect("Failed to create output file");
 
     // コード生成
@@ -62,22 +70,20 @@ fn main() {
 
     // コンパイル
     println!("\n[*] Compiling...");
-    compile_rs_file(&config);
-
-    // 中間生成ファイルの削除
-    if !config.save_temps {
-        std::fs::remove_file(&config.out_rs_file).expect("Failed to remove intermediate file");
+    if let Err(e) = compile_rs_file(&config.rs_file, &config.exe_file) {
+        return e;
     }
 
     println!("[*] Completed.");
+    ExitCode::SUCCESS
 }
 
-/// コンパイル
-fn compile_rs_file(config: &Config) {
+/// rustc でコンパイル
+fn compile_rs_file(rs_file: &str, exe_file: &str) -> Result<(), ExitCode> {
     let status = std::process::Command::new("rustc")
-        .arg(&config.out_rs_file)
+        .arg(rs_file)
         .arg("-o")
-        .arg(&config.exe_file)
+        .arg(exe_file)
         .arg("--crate-name") // クレート名に使用できないファイル名の場合に必要
         .arg("shol_generated")
         .status()
@@ -85,15 +91,14 @@ fn compile_rs_file(config: &Config) {
 
     if !status.success() {
         eprintln!("rustc returned with non-zero exit code");
-        if !config.save_temps {
-            std::fs::remove_file(&config.out_rs_file).ok();
-        }
-        std::process::exit(1);
+        Err(ExitCode::FAILURE)
+    } else {
+        Ok(())
     }
 }
 
 /// コマンドライン引数のパース
-fn parse_args(args: Vec<String>) -> Config {
+fn parse_args(args: Vec<String>) -> Result<Config, ExitCode> {
     fn print_usage(program: &str, opts: &Options) {
         let brief = format!("Usage: {} [options] <src_file>", program);
         print!("{}", opts.usage(&brief));
@@ -111,26 +116,26 @@ fn parse_args(args: Vec<String>) -> Config {
         Ok(m) => m,
         Err(f) => {
             eprintln!("{}", f);
-            std::process::exit(1);
+            return Err(ExitCode::FAILURE);
         }
     };
 
     if matches.opt_present("h") {
         print_usage(&program, &opts);
-        std::process::exit(0);
+        return Err(ExitCode::SUCCESS);
     }
 
     if matches.free.is_empty() {
         eprintln!("エラー: ソースファイルが指定されていません");
         print_usage(&program, &opts);
-        std::process::exit(1);
+        return Err(ExitCode::FAILURE);
     }
 
     let src_file = matches.free[0].clone();
     let save_temps = matches.opt_present("save-temps");
 
     // 出力ファイル名の設定
-    let out_rs_file = if save_temps {
+    let rs_file = if save_temps {
         format!("{}.rs", src_file.trim_end_matches(".shol"))
     } else {
         Builder::new()
@@ -142,18 +147,22 @@ fn parse_args(args: Vec<String>) -> Config {
             .into_owned()
     };
 
-    let out_shi_file = format!("{}.shi", src_file.trim_end_matches(".shol"));
+    let shi_file = if save_temps {
+        Some(format!("{}.shi", src_file.trim_end_matches(".shol")))
+    } else {
+        None
+    };
+
     let exe_file = if cfg!(target_os = "windows") {
         format!("{}.exe", src_file.trim_end_matches(".shol"))
     } else {
         src_file.trim_end_matches(".shol").to_string()
     };
 
-    Config {
+    Ok(Config {
         src_file,
-        save_temps,
-        out_rs_file,
-        out_shi_file,
+        shi_file,
+        rs_file,
         exe_file,
-    }
+    })
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,7 @@
 use lalrpop_util::lalrpop_mod;
+use getopts::Options;
+use std::env;
+use tempfile::Builder;
 
 pub mod ast;
 pub mod tokens;
@@ -8,25 +11,20 @@ pub mod semantics;
 pub mod code_generator;
 lalrpop_mod!(pub shol);
 
-fn main() {
-    // コマンドライン引数
-    let args: Vec<String> = std::env::args().collect();
-    if args.len() != 2 {
-        eprintln!("Usage: {} <src_file>", args[0]);
-        std::process::exit(1);
-    }
-    let src_file = &args[1];
+/// コマンドライン引数をパースして得られる設定
+struct Config {
+    src_file: String,
+    save_temps: bool,
+    out_rs_file: String,
+    exe_file: String,
+}
 
-    // 出力ファイル名の設定
-    let out_rs_file = format!("{}.rs", src_file.trim_end_matches(".shol"));
-    let exe_file = if cfg!(target_os = "windows") {
-        format!("{}.exe", src_file.trim_end_matches(".shol"))
-    } else {
-        src_file.trim_end_matches(".shol").to_string()
-    };
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    let config = parse_args(args);
 
     // 入力ファイルの読み込み
-    let program = std::fs::read_to_string(src_file)
+    let program = std::fs::read_to_string(&config.src_file)
         .expect("Failed to read program file");
 
     // 前処理
@@ -48,29 +46,106 @@ fn main() {
     println!("{{\"AST\":{:?}}}", ast);
 
     // 出力ファイルを開く
-    let mut out_file = std::fs::File::create(&out_rs_file)
+    let mut out_file = std::fs::File::create(&config.out_rs_file)
         .expect("Failed to create output file");
 
     // コード生成
     println!("\n[*] Generating code...");
-    code_generator::generate(&mut out_file, &ast, src_file)
+    code_generator::generate(&mut out_file, &ast, &config.src_file)
         .expect("Failed to write code");
 
     // コンパイル
     println!("\n[*] Compiling...");
+    compile_rs_file(&config);
+
+    // 中間生成ファイルの削除
+    if !config.save_temps {
+        std::fs::remove_file(&config.out_rs_file).expect("Failed to remove intermediate file");
+    }
+
+    println!("[*] Completed.");
+}
+
+/// コンパイル
+fn compile_rs_file(config: &Config) {
     let status = std::process::Command::new("rustc")
-        .arg(&out_rs_file)
+        .arg(&config.out_rs_file)
         .arg("-o")
-        .arg(exe_file)
+        .arg(&config.exe_file)
+        .arg("--crate-name") // クレート名に使用できないファイル名の場合に必要
+        .arg("shol_generated")
         .status()
         .expect("Failed to execute rustc");
+
     if !status.success() {
         eprintln!("rustc returned with non-zero exit code");
+        if !config.save_temps {
+            std::fs::remove_file(&config.out_rs_file).ok();
+        }
+        std::process::exit(1);
+    }
+}
+
+/// コマンドライン引数のパース
+fn parse_args(args: Vec<String>) -> Config {
+    fn print_usage(program: &str, opts: &Options) {
+        let brief = format!("Usage: {} [options] <src_file>", program);
+        print!("{}", opts.usage(&brief));
+    }
+
+    let program = args[0].clone();
+
+    // コマンドラインオプションの設定
+    let mut opts = Options::new();
+    opts.optflag("h", "help", "このヘルプメッセージを表示します");
+    opts.optflag("S", "save-temps", "中間生成ファイルを保持します");
+
+    // オプションのパース
+    let matches = match opts.parse(&args[1..]) {
+        Ok(m) => m,
+        Err(f) => {
+            eprintln!("{}", f);
+            std::process::exit(1);
+        }
+    };
+
+    if matches.opt_present("h") {
+        print_usage(&program, &opts);
+        std::process::exit(0);
+    }
+
+    if matches.free.is_empty() {
+        eprintln!("エラー: ソースファイルが指定されていません");
+        print_usage(&program, &opts);
         std::process::exit(1);
     }
 
-    // 中間生成ファイルの削除
-    // std::fs::remove_file(&out_rs_file).expect("Failed to remove intermediate file");
+    let src_file = matches.free[0].clone();
+    let save_temps = matches.opt_present("save-temps");
 
-    println!("[*] Completed.");
+    // 出力ファイル名の設定
+    let out_rs_file = if save_temps {
+        format!("{}.rs", src_file.trim_end_matches(".shol"))
+    } else {
+        Builder::new()
+            .suffix(".rs")
+            .tempfile()
+            .expect("一時ファイルの作成に失敗しました")
+            .path()
+            .to_string_lossy()
+            .into_owned()
+    };
+
+    let exe_file = if cfg!(target_os = "windows") {
+        format!("{}.exe", src_file.trim_end_matches(".shol"))
+    } else {
+        src_file.trim_end_matches(".shol").to_string()
+    };
+
+    Config {
+        src_file,
+        save_temps,
+        out_rs_file,
+        exe_file,
+    }
 }


### PR DESCRIPTION
close #27

## 通常コンパイル
```
shol example/fizzbuzz.shol
```
で以下が生成されます。
- `example/fizzbuzz.exe` or `example/fizzbuzz`：実行可能ファイル

トランスパイル結果の `.rs` ファイルは、例えば Mac なら `/var/folders/` のどこかに一時ファイルとして保存されます。
main 関数を抜けたら `tempfile::NamedTempFile` のデストラクタが呼ばれて自動で削除されるらしいです。
return や panic! で終了したなら問題なし、sys::process::exit で終了したらリソースリークになります。

## 中間生成ファイルも含めて出力
```
shol example/fizzbuzz.shol -S
```
で以下が生成されます。
- `example/fizzbuzz.shi`：プリプロセス結果
- `example/fizzbuzz.rs`：トランスパイル結果
- `example/fizzbuzz.exe` or `example/fizzbuzz`：実行可能ファイル

## ヘルプを表示

```
shol --help
```
で以下が表示されます。
```
Usage: target/debug/shol [options] <src_file>

Options:
    -h, --help          このヘルプメッセージを表示します
    -S, --save-temps    中間生成ファイルを保持します
```

## cargo run で実行する時の注意

cargo のオプションと区別するために `--` をつけてください。
```
cargo run -- --help
cargo run -- example/fizzbuzz.shol -S
```