### PR TITLE
Feature: 型ヒントを実装

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -128,6 +128,7 @@ impl fmt::Debug for ExprAST {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum UnaryOpcode {
     Neg,
+    As(semantics::Type),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/code_generator.rs
+++ b/src/code_generator.rs
@@ -769,11 +769,10 @@ fn generate_expr(
                 (operand_type, String::from_utf8(buffer).unwrap())
             };
 
-            write!(f, "(",)?;
             match opcode {
-                UnaryOpcode::Neg => write!(f, "-{}", operand_code)?,
+                UnaryOpcode::Neg => write!(f, "(-{})", operand_code)?,
+                UnaryOpcode::As(_) => write!(f, "{}", operand_code)?,
             }
-            write!(f, ")",)?;
 
             match opcode.result_type(operand_type) {
                 Some(t) => result_type = t,

--- a/src/semantics.rs
+++ b/src/semantics.rs
@@ -242,6 +242,18 @@ fn analyze_condition(condition: &mut ast::ConditionAST, rule_meta: &mut RuleASTM
         },
     }
 
+    // $:int のような場合は キャプチャ単体 に変換する
+    let kind = match &condition.expr {
+        ast::ExprAST::UnaryOp(UnaryOpcode::As(_), operand) => {
+            if let ast::ExprAST::Capture(name) = &**operand {
+                ConditionKind::Capture(name.clone())
+            } else {
+                kind
+            }
+        }
+        _ => kind
+    };
+
     // AST にメタデータを追加
     condition.meta = Some(ConditionASTMeta { kind });
 }
@@ -283,6 +295,7 @@ fn analyze_output(outputs: &mut Vec<ast::OutputAST>, captures: &mut HashMap<Stri
 // MARK: 条件式の型推論
 
 /// 条件式の種別を取得
+/// NOTE: $:int のような場合は キャプチャ条件式 と判定する
 fn condition_kind(expr: &ast::ExprAST) -> ConditionKind {
     match expr {
         ast::ExprAST::Number(_) => ConditionKind::Equal(Type::Int),

--- a/src/semantics.rs
+++ b/src/semantics.rs
@@ -85,6 +85,9 @@ impl UnaryOpcodeSignature {
             UnaryOpcode::Neg => vec![
                 Self { operand: Type::Int, result: Type::Int },
             ],
+            UnaryOpcode::As(t) => vec![
+                Self { operand: t, result: t },
+            ],
         }
     }
 }

--- a/src/shol.lalrpop
+++ b/src/shol.lalrpop
@@ -1,6 +1,6 @@
 use crate::tokens::{Token, LexicalError};
 use crate::ast;
-
+use crate::semantics;
 grammar;
 
 // MARK: 構文
@@ -92,6 +92,15 @@ OutputsEndsWithExpr: (Vec<ast::OutputAST>, Option<String>) = {
 Expr: Box<ast::ExprAST> = {
     #[precedence(level="1")]
     <Factor>,
+    <Factor> ":int" => {
+        Box::new(ast::ExprAST::UnaryOp(ast::UnaryOpcode::As(semantics::Type::Int), <>))
+    },
+    <Factor> ":str" => {
+        Box::new(ast::ExprAST::UnaryOp(ast::UnaryOpcode::As(semantics::Type::String), <>))
+    },
+    <Factor> ":bool" => {
+        Box::new(ast::ExprAST::UnaryOp(ast::UnaryOpcode::As(semantics::Type::Bool), <>))
+    },
 
     #[precedence(level="2")] #[assoc(side="left")]
     <lhs:Expr> "*" <rhs:Expr> => {
@@ -199,6 +208,9 @@ extern {
         "*" => Token::Mul,
         "/" => Token::Div,
         "%" => Token::Mod,
+        ":int" => Token::AsInt,
+        ":str" => Token::AsStr,
+        ":bool" => Token::AsBool,
         "." => Token::Dot,
         "|" => Token::Pipe,
         "," => Token::Comma,

--- a/src/tokens.rs
+++ b/src/tokens.rs
@@ -125,6 +125,12 @@ pub enum Token {
     Div,
     #[token("%")]
     Mod,
+    #[token(":int")]
+    AsInt,
+    #[token(":str")]
+    AsStr,
+    #[token(":bool")]
+    AsBool,
 
     // 構文に使われる記号
     #[token(".")]


### PR DESCRIPTION
close #12

単項演算子として、型ヒントを実装しました。

## 例 1

```
. $:int #print $
```
→ `int` 型のリソースだけを print します。

## 例 2

```
. $a, $b #print ($a+$b):str
```
→ `$a: {String}, $b: {Int, Bool, String}` として推論されます。

## 補足

条件式 `$:int` は `$` と同じく キャプチャ単体 に分類されます。
ただし `($:int):int` は キャプチャ条件式 に分類されます。

なお、以下のコードで `rustc` のコンパイルエラーが出ますが、意図したものではありません。
```
. ($:int):int #print $
```
キャプチャ条件式の型が `bool` にならないので意味解析の段階でエラーを出す必要がありますが、実装漏れしていました。
既に Issue を立てています: #35
