### PR TITLE
Feature: 標準入力 `cin` コロニーを実装

### DIFF
--- a/src/code_generator.rs
+++ b/src/code_generator.rs
@@ -232,8 +232,8 @@ pub fn generate(
     // 標準入力を cin コロニーに送信
     if contains_cin {
         writeln!(f, "      if let Ok({}) = {}.try_recv() {{", Identf::V_LINE, Identf::V_RX)?;
-        writeln!(f, "        {}[0].{}(vec![{}({})]);", Identf::V_COLONIES, Identf::FN_RECEIVE,
-            Identf::en_type(Type::String), Identf::V_LINE)?;
+        writeln!(f, "        {}[{}].{}(vec![{}({})]);", Identf::V_COLONIES, colony_indices[&"cin".to_string()],
+            Identf::FN_RECEIVE, Identf::en_type(Type::String), Identf::V_LINE)?;
         writeln!(f, "      }}")?;
     }
 


### PR DESCRIPTION
close #18 

`std::thread` で標準入力を受け付けるスレッドを作成し、mpsc で入力をメインスレッドに受け渡します。([The Book](https://doc.rust-jp.rs/book-ja/ch16-00-concurrency.html) で学びました)

動作するプログラム例：

```
*cin
. $ #print $+", you said."
| $ #exit 0

%print
%exit
```
`Hello` → `Hello, you said` と出力されて終了