### PR TITLE
Fix: 生成コードのインデントのミスを修正

### DIFF
--- a/src/code_generator.rs
+++ b/src/code_generator.rs
@@ -748,7 +748,9 @@ fn generate_single_condition_rule(
             write!(f, "          if {}.clone() == {} ", Identf::V_VALUE_REF, expr_str)?;
         },
         // 無条件で出力式を push
-        ConditionKind::Capture(_) => (),
+        ConditionKind::Capture(_) => {
+            write!(f, "          ")?;
+        },
         // 条件式を満たすならば出力式を push
         ConditionKind::CaptureCondition(_) => {
             write!(f, "          if ")?;


### PR DESCRIPTION
単一キャプチャ条件の単一条件規則で、`{`の前のインデントがなくなっていたので修正