### PR TITLE
Feature: 字句解析・構文解析でのコンパイルエラーを実装

### DIFF
--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -19,10 +19,13 @@ impl<'input> Iterator for Lexer<'input> {
 
     fn next(&mut self) -> Option<Self::Item> {
         self.token_stream.next().map(|(token, span)| {
-            // デバッグ出力
-            println!("token {}-{}: {:?}", span.start, span.end, token);
-            // トークンがエラーの場合も、ここで ? によりエラーを伝播
-            Ok((span.start, token?, span.end))
+            match token {
+                Ok(token) => Ok((span.start, token, span.end)),
+                Err(mut error) => {
+                    error.range = span; // エラー発生位置の情報を付加
+                    Err(error)
+                }
+            }
         })
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ use tempfile;
 pub mod ast;
 pub mod tokens;
 pub mod lexer;
+pub mod parser;
 pub mod preprocessor;
 pub mod semantics;
 pub mod code_generator;
@@ -77,10 +78,10 @@ fn main() -> ExitCode {
 
     // AST 生成
     println!("[*] AST generating...");
-    let mut lexer = lexer::Lexer::new(&program);
-    let parser = shol::ProgramParser::new();
-    let mut ast = parser.parse(&mut lexer)
-        .expect("Failed to parse program");
+    let mut ast = match parser::parse_program(&program) {
+        Ok(ast) => ast,
+        Err(e) => return e,
+    };
     println!("{{\"AST\":{:?}}}", ast);
 
     // 意味解析

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -184,6 +184,13 @@ fn convert_lexical_error(error: tokens::LexicalError, program: &str) -> SyntaxEr
                 line, column, length,
                 message: "浮動小数点リテラルを double 型の値にパースできません。".to_string()
             },
+        tokens::LexicalErrorKind::InvalidStringEscape { message, position } =>
+            SyntaxError {
+                line,
+                column: column + position.start + 1,
+                length: position.end - position.start,
+                message: format!("{}", message)
+            },
     }
 }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -172,7 +172,12 @@ fn convert_lexical_error(error: tokens::LexicalError, program: &str) -> SyntaxEr
         tokens::LexicalErrorKind::InvalidToken =>
             SyntaxError {
                 line, column, length,
-                message: "無効なトークンです。".to_string()
+                // message: "無効なトークンです。".to_string()
+                message: if let Some('"') = program.chars().nth(error.range.start) {
+                    "文字列リテラルが閉じられていません。".to_string()
+                } else {
+                    "無効なトークンです。".to_string()
+                }
             },
         tokens::LexicalErrorKind::InvalidIntegerLiteral =>
             SyntaxError {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,0 +1,177 @@
+use std::process::ExitCode;
+use std::usize;
+use lalrpop_util::ParseError;
+use crate::shol;
+use crate::lexer;
+use crate::ast;
+use crate::tokens;
+
+// MARK: 構文解析
+
+/// プログラムを構文解析して AST を生成
+pub fn parse_program(program: &str) -> Result<Vec<ast::StatementAST>, ExitCode> {
+    let mut lexer = lexer::Lexer::new(&program);
+    let parser = shol::ProgramParser::new();
+    let parse_result = parser.parse(&mut lexer);
+    match parse_result {
+        Ok(ast) => Ok(ast),
+        Err(err) => {
+            let compile_error = convert_parse_error(err, &program);
+            eprintln!("{}", compile_error.format(&program));
+            return Err(ExitCode::FAILURE);
+        }
+    }
+}
+
+// MARK: エラー型
+
+/// コンパイルエラー型
+#[derive(Debug)]
+    /// 構文解析エラー
+struct SyntaxError {
+    /// エラーが発生した位置（行）
+    line: usize,
+    /// エラーが発生した位置（列）
+    column: usize,
+    /// エラーが発生した位置(長さ)
+    length: usize,
+    /// エラーメッセージ
+    message: String
+}
+
+impl SyntaxError {
+    /// コンパイルエラーとして出力するエラーメッセージを生成
+    pub fn format(&self, source: &str) -> String {
+        let line = self.line;
+        let column = self.column;
+        let length = self.length;
+        let line_content = source.lines().nth(line - 1).unwrap_or("");
+
+        // エラー位置を示す矢印を作成
+        let mut pointer = String::new();
+        for _ in 0..column-1 {
+            pointer.push(' ');
+        }
+        pointer.push_str("\x1b[1;31m");
+        for _ in 0..length {
+            pointer.push('^');
+        }
+        pointer.push_str("\x1b[0m");
+
+        // エラーメッセージを整形
+        let line = line.to_string();
+        format!(
+            "{red}構文エラー{reset}: {msg}\n\
+            {blue}  -->{reset} {line} 行目 {column} 文字目\n\
+            {blue}{space} |\n\
+            {line} | {reset}{line_content}\n\
+            {blue}{space} | {reset}{pointer}\n",
+            red = "\x1b[1;31m",
+            blue = "\x1b[1;34m",
+            reset = "\x1b[0m",
+            msg = self.message,
+            space = " ".repeat(line.len()),
+        )
+    }
+}
+
+// MARK: トークンフォーマット
+
+/// 文法ファイルのトークン名を人間が読める形式に変換
+fn format_token(token: &str) -> Option<String> {
+    let token = &token[1..token.len()-1];
+    match token {
+        "identf" => Some("識別子".to_string()),
+        "double" => Some("doubleリテラル".to_string()),
+        "int" => Some("intリテラル".to_string()),
+        "intmin" => None,
+        "str" => Some("strリテラル".to_string()),
+        "true" => Some("boolリテラル".to_string()),
+        "false" => None,
+        "nl" => Some("改行".to_string()),
+        "#xx" => Some("`#`".to_string()),
+        "$xx" => Some("`$`".to_string()),
+        _ => Some(format!("`{}`", token)),
+    }
+}
+
+/// 期待されるトークンのリストを整形
+fn format_expected_tokens(tokens: &[String]) -> String {
+    if tokens.is_empty() {
+        "なし".to_string()
+    } else {
+        tokens
+            .iter()
+            .filter_map(|token| format_token(token))
+            .collect::<Vec<String>>()
+            .join(", ")
+    }
+}
+
+// MARK: エラー変換
+
+/// LALRPOP のエラーを CompileError に変換
+fn convert_parse_error(error: ParseError<usize, tokens::Token, tokens::LexicalError>, program: &str) -> SyntaxError {
+    match error {
+        ParseError::InvalidToken { location } => {
+            // どういう時にこのエラーが出るのか不明
+            let (line, column) = position_to_line_column(program, location);
+            SyntaxError {
+                line,
+                column,
+                length: 1,
+                message: "無効なトークンです".to_string()
+            }
+        },
+        ParseError::UnrecognizedEof { location, expected } => {
+            let (line, column) = position_to_line_column(program, location);
+            SyntaxError {
+                line,
+                column,
+                length: 1,
+                message: format!("予期せぬファイル終端です。期待されるトークン: {}", format_expected_tokens(&expected))
+            }
+        },
+        ParseError::UnrecognizedToken { token: (start, _, end), expected } => {
+            let (line, column) = position_to_line_column(program, start);
+            SyntaxError {
+                line,
+                column,
+                length: end - start,
+                message: format!("予期せぬトークンです。期待されるトークン: {}", format_expected_tokens(&expected))
+            }
+        },
+        ParseError::ExtraToken { token: (start, _, end) } => {
+            // どういう時にこのエラーが出るのか不明
+            let (line, column) = position_to_line_column(program, start);
+            SyntaxError {
+                line,
+                column,
+                length: end - start,
+                message: format!("無効な文法です。")
+            }
+        },
+        ParseError::User { error } => {
+            SyntaxError {
+                line: 1,
+                column: 1,
+                length: 0,
+                message: format!("TODO: {:?}", error)
+            }
+        },
+    }
+}
+
+/// 行と列の位置に変換
+fn position_to_line_column(program: &str, pos: usize) -> (usize, usize) {
+    program
+        .chars()
+        .take(pos)
+        .fold((1, 1), |(line, col), c| {
+            if c == '\n' {
+                (line + 1, 1)
+            } else {
+                (line, col + 1)
+            }
+        })
+}

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -88,7 +88,7 @@ fn format_token(token: &str) -> Option<String> {
         "str" => Some("strリテラル".to_string()),
         "true" => Some("boolリテラル".to_string()),
         "false" => None,
-        "nl" => Some("改行".to_string()),
+        "nl" => Some("行終端".to_string()),
         "#xx" => Some("`#`".to_string()),
         "$xx" => Some("`$`".to_string()),
         _ => Some(format!("`{}`", token)),

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -132,13 +132,18 @@ fn convert_parse_error(error: ParseError<usize, tokens::Token, tokens::LexicalEr
                 message: format!("予期せぬファイル終端です。期待されるトークン: {}", format_expected_tokens(&expected))
             }
         },
-        ParseError::UnrecognizedToken { token: (start, _, end), expected } => {
+        ParseError::UnrecognizedToken { token: (start, token, end), expected } => {
             let (line, column) = position_to_line_column(program, start);
             SyntaxError {
                 line,
                 column,
                 length: end - start,
-                message: format!("予期せぬトークンです。期待されるトークン: {}", format_expected_tokens(&expected))
+                message: match token {
+                    tokens::Token::NewLine =>
+                        format!("予期せぬ行終端です。期待されるトークン: {}", format_expected_tokens(&expected)),
+                    _ =>
+                        format!("予期せぬトークンです。期待されるトークン: {}", format_expected_tokens(&expected)),
+                }
             }
         },
         ParseError::ExtraToken { token: (start, _, end) } => {

--- a/src/shol.lalrpop
+++ b/src/shol.lalrpop
@@ -298,6 +298,6 @@ extern {
         "," => Token::Comma,
         "#xx" => Token::Destination(<Option<String>>),
         "$xx" => Token::Capture(<String>),
-        "nl" => Token::NewLine(<String>),
+        "nl" => Token::NewLine,
     }
 }

--- a/src/tokens.rs
+++ b/src/tokens.rs
@@ -118,8 +118,8 @@ pub enum Token {
     Capture(String),
 
     // 改行
-    #[regex(r"\n|\r\n|\r|\f", |lex| lex.slice().to_string())]
-    NewLine(String),
+    #[regex(r"\n|\r\n|\r|\f")]
+    NewLine,
 }
 
 impl fmt::Display for Token {

--- a/src/tokens.rs
+++ b/src/tokens.rs
@@ -1,24 +1,53 @@
 use std::num::{ ParseIntError, ParseFloatError };
+use std::ops::Range;
 use logos::Logos;
 use std::fmt;
 
-// MARK: エラー型
+// MARK: LexicalError
 
-#[derive(Default, Debug, Clone, PartialEq)]
-pub enum LexicalError {
-    #[default]
-    InvalidToken,
+#[derive(Debug, Clone, PartialEq)]
+pub struct LexicalError {
+    /// エラーが発生した範囲 (Lexer が後から設定する)
+    pub range: Range<usize>,
+    /// エラーの種類
+    pub error_type: LexicalErrorKind,
 }
 
-impl From<ParseIntError> for LexicalError {
-    fn from(_: ParseIntError) -> Self {
-        LexicalError::InvalidToken
+/// エラーの種類
+#[derive(Debug, Clone, PartialEq)]
+pub enum LexicalErrorKind {
+    /// 無効なトークン
+    InvalidToken,
+    /// 整数パースエラー
+    InvalidIntegerLiteral,
+    /// 浮動小数点パースエラー
+    InvalidFloatLiteral,
+}
+
+// MARK: LexicalError の生成ルール
+
+impl Default for LexicalError {
+    fn default() -> Self {
+        LexicalError {
+            range: 0..0,
+            error_type: LexicalErrorKind::InvalidToken,
+        }
     }
 }
-
+impl From<ParseIntError> for LexicalError {
+    fn from(_: ParseIntError) -> Self {
+        LexicalError {
+            range: 0..0,
+            error_type: LexicalErrorKind::InvalidIntegerLiteral,
+        }
+    }
+}
 impl From<ParseFloatError> for LexicalError {
     fn from(_: ParseFloatError) -> Self {
-        LexicalError::InvalidToken
+        LexicalError {
+            range: 0..0,
+            error_type: LexicalErrorKind::InvalidFloatLiteral,
+        }
     }
 }
 

--- a/src/tokens.rs
+++ b/src/tokens.rs
@@ -166,62 +166,69 @@ fn decode_string(input: &str) -> String {
     let mut chars = without_quotes.chars().peekable();
 
     while let Some(c) = chars.next() {
-        if c == '\\' {
-            if let Some(next) = chars.next() {
-                match next {
-                    '0' => result.push('\0'),
-                    'a' => result.push('\x07'),
-                    'b' => result.push('\x08'),
-                    't' => result.push('\t'),
-                    'n' => result.push('\n'),
-                    'v' => result.push('\x0b'),
-                    'f' => result.push('\x0c'),
-                    'r' => result.push('\r'),
-                    'e' => result.push('\x1b'),
-                    '"' => result.push('"'),
-                    '\\' => result.push('\\'),
-                    'x' => {
-                        let hex = chars.by_ref().take(2).collect::<String>();
-                        let code = match (hex.len() == 2, u8::from_str_radix(&hex, 16)) {
-                            (true, Ok(code)) => code,
-                            _ => panic!("Unicode エスケープ \\xXX をデコードできません: \\x{}", hex),
-                        };
-                        result.push(code as char);
-                    },
-                    'u' => {
-                        let hex = chars.by_ref().take(4).collect::<String>();
-                        let code = match (hex.len() == 4, u16::from_str_radix(&hex, 16)) {
-                            (true, Ok(code)) => code,
-                            _ => panic!("Unicode エスケープ \\uXXXX をデコードできません: \\u{}", hex),
-                        };
-                        let c = match char::from_u32(code as u32) {
-                            Some(c) => c,
-                            None => panic!("Unicode エスケープ \\u{} は不正な文字です。", hex),
-                        };
-                        result.push(c);
-                    },
-                    'U' => {
-                        let hex = chars.by_ref().take(8).collect::<String>();
-                        let code = match (hex.len() == 8, u32::from_str_radix(&hex, 16)) {
-                            (true, Ok(code)) => code,
-                            _ => panic!("Unicode エスケープ \\UXXXXXXXX をデコードできません: \\U{}", hex),
-                        };
-                        let c = match char::from_u32(code) {
-                            Some(c) => c,
-                            None => panic!("Unicode エスケープ \\U{} は不正な文字です。", hex),
-                        };
-                        result.push(c);
-                    },
-                    _ => {
-                        result.push('\\');
-                        result.push(next);
-                    }
-                }
-            }
-        } else {
+        if c != '\\' {
             result.push(c);
+            continue;
         }
-    }
+
+        let next = {
+            let next = chars.next();
+            if next.is_none() {
+                result.push(c);
+                break;
+            }
+            next.unwrap()
+        };
+        match next {
+            '0' => result.push('\0'),
+            'a' => result.push('\x07'),
+            'b' => result.push('\x08'),
+            't' => result.push('\t'),
+            'n' => result.push('\n'),
+            'v' => result.push('\x0b'),
+            'f' => result.push('\x0c'),
+            'r' => result.push('\r'),
+            'e' => result.push('\x1b'),
+            '"' => result.push('"'),
+            '\\' => result.push('\\'),
+            'x' => {
+                let hex = chars.by_ref().take(2).collect::<String>();
+                let code = match (hex.len() == 2, u8::from_str_radix(&hex, 16)) {
+                    (true, Ok(code)) => code,
+                    _ => panic!("Unicode エスケープ \\xXX をデコードできません: \\x{}", hex),
+                };
+                result.push(code as char);
+            },
+            'u' => {
+                let hex = chars.by_ref().take(4).collect::<String>();
+                let code = match (hex.len() == 4, u16::from_str_radix(&hex, 16)) {
+                    (true, Ok(code)) => code,
+                    _ => panic!("Unicode エスケープ \\uXXXX をデコードできません: \\u{}", hex),
+                };
+                let c = match char::from_u32(code as u32) {
+                    Some(c) => c,
+                    None => panic!("Unicode エスケープ \\u{} は不正な文字です。", hex),
+                };
+                result.push(c);
+            },
+            'U' => {
+                let hex = chars.by_ref().take(8).collect::<String>();
+                let code = match (hex.len() == 8, u32::from_str_radix(&hex, 16)) {
+                    (true, Ok(code)) => code,
+                    _ => panic!("Unicode エスケープ \\UXXXXXXXX をデコードできません: \\U{}", hex),
+                };
+                let c = match char::from_u32(code) {
+                    Some(c) => c,
+                    None => panic!("Unicode エスケープ \\U{} は不正な文字です。", hex),
+                };
+                result.push(c);
+            },
+            _ => {
+                result.push('\\');
+                result.push(next);
+            }
+        }
+    } // while let Some(c) = chars.next()
     result
 }
 


### PR DESCRIPTION
related to #19 

字句解析・構文解析失敗時に panic していた部分を、ユーザーフレンドリーなコンパイルエラーを出力して、ちゃんと main 関数から終了コード 1 を return するように改善しました。

意味解析のコンパイルエラーは、別のPRでやります。