### PR TITLE
Feature: オペレータの種類を増強

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -213,6 +213,16 @@ pub enum UnaryOpcode {
     LogicalNot,
     BitNot,
     As(semantics::Type),
+    ToInt,
+    ToDouble,
+    ToString,
+    UtilCeil,
+    UtilFloor,
+    UtilRound,
+    UtilAbs,
+    UtilOrd,
+    UtilChr,
+    UtilLen,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -259,4 +259,5 @@ pub enum Opcode {
     Gt,
     Le,
     Ge,
+    Nth,
 }

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -180,6 +180,7 @@ pub enum ExprAST {
     Capture(String, Range<usize>),
     UnaryOp(UnaryOpcode, Box<ExprAST>, Range<usize>),
     BinaryOp(Box<ExprAST>, Opcode, Box<ExprAST>, Range<usize>),
+    Slice(Box<ExprAST>, Option<Box<ExprAST>>, Option<Box<ExprAST>>, Option<Box<ExprAST>>, Range<usize>),
 }
 
 impl fmt::Debug for ExprAST {
@@ -201,6 +202,19 @@ impl fmt::Debug for ExprAST {
                 write!(f, "{{\"BinaryOp({:?})\":{:?}}}", op, operand),
             ExprAST::BinaryOp(lhs, op, rhs, _) =>
                 write!(f, "{{\"BinaryOp({:?})\":{{\".lhs\":{:?},\".rhs\":{:?}}}}}", op, lhs, rhs),
+            ExprAST::Slice(s, start, end, step, _) => {
+                write!(f, "{{\"Slice\":{{\".s\":{:?}", s)?;
+                if let Some(start) = start {
+                    write!(f, ",\".start\":{:?}", start)?;
+                }
+                if let Some(end) = end {
+                    write!(f, ",\".end\":{:?}", end)?;
+                }
+                if let Some(step) = step {
+                    write!(f, ",\".step\":{:?}", step)?;
+                }
+                write!(f, "}}}}")
+            }
         }
     }
 }

--- a/src/code_generator.rs
+++ b/src/code_generator.rs
@@ -60,6 +60,9 @@ impl Identf {
     /// fn (&str, Option<i32>, Option<i32>, Option<i32>) -> String
     /// : 文字列のスライスを行うユーティリティ関数
     const FN_UTIL_SLICE: &'static str = "slice";
+    /// fn (String, i32) -> String
+    /// : 文字列の n 番目の文字を取得するユーティリティ関数
+    const FN_UTIL_NTH: &'static str = "nth";
 
     /// Vec<EN_TYPE>: リソースのメンバ変数
     const ME_RESOURCE: &'static str = "resources";
@@ -68,14 +71,18 @@ impl Identf {
     const P_GIFTS: &'static str = "g";
     /// &Type::actual: ユーティリティ関数の引数
     const P_UTIL_ARG: &'static str = "a";
-    /// &str: ユーティリティ関数の引数
+    /// &str: FN_UTIL_SLICE の引数
     const P_SLICE_S: &'static str = "s";
-    /// Option<i32>: ユーティリティ関数の引数
+    /// Option<i32>: FN_UTIL_SLICE の引数
     const P_SLICE_START: &'static str = "start";
-    /// Option<i32>: ユーティリティ関数の引数
+    /// Option<i32>: FN_UTIL_SLICE の引数
     const P_SLICE_END: &'static str = "end";
-    /// Option<i32>: ユーティリティ関数の引数
+    /// Option<i32>: FN_UTIL_SLICE の引数
     const P_SLICE_STEP: &'static str = "step";
+    /// String: FN_UTIL_NTH の引数
+    const P_NTH_S: &'static str = "s";
+    /// i32: FN_UTIL_NTH の引数
+    const P_NTH_N: &'static str = "n";
 
     /// [&str;n]: シンボルの名前対応表
     const V_SYMBOLS: &'static str = "SYMBOLS";
@@ -244,10 +251,16 @@ pub fn generate(
     writeln!(f, "fn {0}({1}:i32)->String{{\
         char::from_u32({1} as u32).map(String::from).unwrap_or_default()\
     }}", Identf::FN_UTIL_CHR, Identf::P_UTIL_ARG)?;
+
     writeln!(f, "fn {0}({1}:String)->i32{{\
         {1}.chars().next().unwrap_or(\'\\0\')as i32\
     }}", Identf::FN_UTIL_ORD, Identf::P_UTIL_ARG)?;
-    writeln!(f, "fn {slice}({s}: &str, {start}: Option<i32>, {end}: Option<i32>, {step}: Option<i32>) -> String {{
+
+    writeln!(f, "fn {nth}({s}:String,{n}:i32)->String{{\
+        {s}.chars().nth({n} as usize).map_or_else(String::new,String::from)\
+    }}", nth=Identf::FN_UTIL_NTH, s=Identf::P_NTH_S, n=Identf::P_NTH_N)?;
+
+    writeln!(f, "fn {slice}({s}:&str,{start}:Option<i32>,{end}:Option<i32>,{step}:Option<i32>)->String{{
   let {s}: Vec<char> = {s}.chars().collect();
   let {len} = {s}.len() as i32;
 

--- a/src/code_generator.rs
+++ b/src/code_generator.rs
@@ -1070,6 +1070,7 @@ fn generate_expr(
                 (Opcode::Gt, _, _) => write!(f, "{}>{}", lhs_code, rhs_code)?,
                 (Opcode::Le, _, _) => write!(f, "{}<={}", lhs_code, rhs_code)?,
                 (Opcode::Ge, _, _) => write!(f, "{}>={}", lhs_code, rhs_code)?,
+                (Opcode::Nth, _, _) => write!(f, "nth({},{})", lhs_code, rhs_code)?,
             }
             write!(f, ")",)?;
 

--- a/src/semantic_error.rs
+++ b/src/semantic_error.rs
@@ -150,8 +150,8 @@ impl SemanticError {
         rhs_t: Type,
     ) -> Self {
         let message = format!(
-            "{} {} {} の演算はサポートされていません。",
-            lhs_t, opcode, rhs_t
+            "{} の演算はサポートされていません。",
+            opcode.format(lhs_t.to_string(), rhs_t.to_string()),
         );
         let location = location.clone();
         Self(Box::new(move |source: &str| {
@@ -255,8 +255,8 @@ impl SemanticError {
     ) -> Self {
         let message = format!(
             "出力式の型推論に失敗しました。\n\
-            {} {} {} -> {} は解決できません。",
-            t_lhs.format(), opcode, t_rhs.format(), t_result.format()
+            {} -> {} は解決できません。",
+            opcode.format(t_lhs.format(), t_rhs.format()), t_result.format()
         );
         let location = location.clone();
         Self(Box::new(move |source: &str| {
@@ -454,7 +454,17 @@ impl fmt::Display for Opcode {
             Opcode::Gt => ">",
             Opcode::Le => "<=",
             Opcode::Ge => ">=",
+            Opcode::Nth => "[index]",
         })
+    }
+}
+
+impl Opcode {
+    fn format(&self, lhs: String, rhs: String) -> String {
+        match self {
+            Opcode::Nth => format!("{}[{}]", lhs, rhs),
+            _ => format!("{} {} {}", lhs, self, rhs),
+        }
     }
 }
 

--- a/src/semantic_error.rs
+++ b/src/semantic_error.rs
@@ -299,6 +299,16 @@ impl UnaryOpcode {
             | UnaryOpcode::BitNot
             => true,
             UnaryOpcode::As(_)
+            | UnaryOpcode::ToInt
+            | UnaryOpcode::ToDouble
+            | UnaryOpcode::ToString
+            | UnaryOpcode::UtilCeil
+            | UnaryOpcode::UtilFloor
+            | UnaryOpcode::UtilRound
+            | UnaryOpcode::UtilAbs
+            | UnaryOpcode::UtilOrd
+            | UnaryOpcode::UtilChr
+            | UnaryOpcode::UtilLen
             => false,
         }
     }
@@ -335,6 +345,16 @@ impl fmt::Display for UnaryOpcode {
             UnaryOpcode::LogicalNot => write!(f, "!"),
             UnaryOpcode::BitNot => write!(f, "~"),
             UnaryOpcode::As(t) => write!(f, ":{}", t),
+            UnaryOpcode::ToInt => write!(f, ".int"),
+            UnaryOpcode::ToDouble => write!(f, ".double"),
+            UnaryOpcode::ToString => write!(f, ".str"),
+            UnaryOpcode::UtilCeil => write!(f, ".ceil"),
+            UnaryOpcode::UtilFloor => write!(f, ".floor"),
+            UnaryOpcode::UtilRound => write!(f, ".round"),
+            UnaryOpcode::UtilAbs => write!(f, ".abs"),
+            UnaryOpcode::UtilOrd => write!(f, ".ord"),
+            UnaryOpcode::UtilChr => write!(f, ".chr"),
+            UnaryOpcode::UtilLen => write!(f, ".len"),
         }
     }
 }

--- a/src/semantic_error.rs
+++ b/src/semantic_error.rs
@@ -162,6 +162,35 @@ impl SemanticError {
         }))
     }
 
+    /// スライスの型エラー
+    pub fn type_error_slice(
+        operand: SliceOperand,
+        operand_t: Type,
+        location: &Range<usize>,
+    ) -> Self {
+        let message = match operand {
+            SliceOperand::String => format!(
+                "{operand_t} 型のスライス演算はサポートされていません。"
+            ),
+            SliceOperand::Start => format!(
+                "スライス演算 [start:end:step] の start に {operand_t} 型は指定できません。"
+            ),
+            SliceOperand::End => format!(
+                "スライス演算 [start:end:step] の end に {operand_t} 型は指定できません。"
+            ),
+            SliceOperand::Step => format!(
+                "スライス演算 [start:end:step] の step に {operand_t} 型は指定できません。"
+            ),
+        };
+        let location = location.clone();
+        Self(Box::new(move |source: &str| {
+            CompileErrorBuilder::new(source, ErrorKind::TypeError)
+                .header(&message, location.start)
+                .location_pointer(&location)
+                .build()
+        }))
+    }
+
     /// 条件式を評価可能なキャプチャ型が存在しない場合のエラー
     pub fn no_type_matches(
         location: &Range<usize>,
@@ -286,6 +315,17 @@ impl SemanticError {
                 .build()
         }))
     }
+}
+
+// MARK: SliceOperand
+
+/// スライス演算のオペランドの種類
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum SliceOperand {
+    String,
+    Start,
+    End,
+    Step,
 }
 
 // MARK: UnaryOpcode::is_prefix

--- a/src/semantics.rs
+++ b/src/semantics.rs
@@ -142,6 +142,43 @@ impl UnaryOpcodeSignature {
             UnaryOpcode::As(t) => vec![
                 Self { operand: t, result: t },
             ],
+            UnaryOpcode::ToInt => vec![
+                Self { operand: Type::Double, result: Type::Int },
+                Self { operand: Type::String, result: Type::Int },
+                Self { operand: Type::Bool, result: Type::Int },
+            ],
+            UnaryOpcode::ToDouble => vec![
+                Self { operand: Type::Int, result: Type::Double },
+                Self { operand: Type::String, result: Type::Double },
+                Self { operand: Type::Bool, result: Type::Double },
+            ],
+            UnaryOpcode::ToString => vec![
+                Self { operand: Type::Int, result: Type::String },
+                Self { operand: Type::Double, result: Type::String },
+                Self { operand: Type::Bool, result: Type::String },
+            ],
+            UnaryOpcode::UtilCeil => vec![
+                Self { operand: Type::Double, result: Type::Int },
+            ],
+            UnaryOpcode::UtilFloor => vec![
+                Self { operand: Type::Double, result: Type::Int },
+            ],
+            UnaryOpcode::UtilRound => vec![
+                Self { operand: Type::Double, result: Type::Int },
+            ],
+            UnaryOpcode::UtilAbs => vec![
+                Self { operand: Type::Int, result: Type::Int },
+                Self { operand: Type::Double, result: Type::Double },
+            ],
+            UnaryOpcode::UtilOrd => vec![
+                Self { operand: Type::String, result: Type::Int },
+            ],
+            UnaryOpcode::UtilChr => vec![
+                Self { operand: Type::Int, result: Type::String },
+            ],
+            UnaryOpcode::UtilLen => vec![
+                Self { operand: Type::String, result: Type::Int },
+            ],
         }
     }
 }

--- a/src/semantics.rs
+++ b/src/semantics.rs
@@ -1109,7 +1109,11 @@ fn analyze_output_ast(
                 AOAResult::Infer { index } => {
                     let t_s = infers[index.0].get_types(captures);
                     if !t_s.contains(&Type::String) {
-                        panic!("{:?} 型のスライスはサポートしていません", t_s);
+                        return Err(SemanticError::type_inference_failed_slice(
+                            SliceOperand::String,
+                            t_s,
+                            op_loc,
+                        ));
                     }
                     request_update(index, &string_t, infers, captures);
                 }
@@ -1132,7 +1136,11 @@ fn analyze_output_ast(
                     Some(AOAResult::Infer { index }) => {
                         let t_result = infers[index.0].get_types(captures);
                         if !t_result.contains(&Type::Int) {
-                            panic!("{:?} 型は start/end/step に指定できません", t_result);
+                            return Err(SemanticError::type_inference_failed_slice(
+                                operand,
+                                t_result,
+                                op_loc,
+                            ));
                         }
                         request_update(index, &int_t, infers, captures);
                     }

--- a/src/semantics.rs
+++ b/src/semantics.rs
@@ -1161,7 +1161,7 @@ fn infer_infers(
 
                     // 推論
                     for signature in UnaryOpcodeSignature::get_signatures(*opcode) {
-                        if t_operand.contains(&signature.operand) {
+                        if t_operand.contains(&signature.operand) && t_result.contains(&signature.result) {
                             new_t_result.insert(signature.result);
                             new_t_operand.insert(signature.operand);
                         }

--- a/src/semantics.rs
+++ b/src/semantics.rs
@@ -227,6 +227,9 @@ impl OpcodeSignature {
                 Self { lhs: Type::Double, rhs: Type::Int, result: Type::Bool },
                 Self { lhs: Type::Double, rhs: Type::Double, result: Type::Bool },
             ],
+            Opcode::Nth => vec![
+                Self { lhs: Type::String, rhs: Type::Int, result: Type::String },
+            ],
         }
     }
 }

--- a/src/shol.lalrpop
+++ b/src/shol.lalrpop
@@ -149,20 +149,50 @@ OutputsEndsWithExpr: (Vec<ast::OutputAST>, Option<String>, Range<usize>) = {
 Expr: Box<ast::ExprAST> = {
     #[precedence(level="1")]
     <Factor>,
-    <e:Factor> <l:@L> ":int" <r:@R> => {
+    <e:Expr> <l:@L> ":int" <r:@R> => {
         Box::new(ast::ExprAST::UnaryOp(ast::UnaryOpcode::As(semantics::Type::Int), e, l..r))
     },
-    <e:Factor> <l:@L> ":double" <r:@R> => {
+    <e:Expr> <l:@L> ":double" <r:@R> => {
         Box::new(ast::ExprAST::UnaryOp(ast::UnaryOpcode::As(semantics::Type::Double), e, l..r))
     },
-    <e:Factor> <l:@L> ":str" <r:@R> => {
+    <e:Expr> <l:@L> ":str" <r:@R> => {
         Box::new(ast::ExprAST::UnaryOp(ast::UnaryOpcode::As(semantics::Type::String), e, l..r))
     },
-    <e:Factor> <l:@L> ":bool" <r:@R> => {
+    <e:Expr> <l:@L> ":bool" <r:@R> => {
         Box::new(ast::ExprAST::UnaryOp(ast::UnaryOpcode::As(semantics::Type::Bool), e, l..r))
     },
-    <e:Factor> <l:@L> ":symbol" <r:@R> => {
+    <e:Expr> <l:@L> ":symbol" <r:@R> => {
         Box::new(ast::ExprAST::UnaryOp(ast::UnaryOpcode::As(semantics::Type::Symbol), e, l..r))
+    },
+    <e:Expr> <l:@L> ".int" <r:@R> => {
+        Box::new(ast::ExprAST::UnaryOp(ast::UnaryOpcode::ToInt, e, l..r))
+    },
+    <e:Expr> <l:@L> ".double" <r:@R> => {
+        Box::new(ast::ExprAST::UnaryOp(ast::UnaryOpcode::ToDouble, e, l..r))
+    },
+    <e:Expr> <l:@L> ".str" <r:@R> => {
+        Box::new(ast::ExprAST::UnaryOp(ast::UnaryOpcode::ToString, e, l..r))
+    },
+    <e:Expr> <l:@L> ".ceil" <r:@R> => {
+        Box::new(ast::ExprAST::UnaryOp(ast::UnaryOpcode::UtilCeil, e, l..r))
+    },
+    <e:Expr> <l:@L> ".floor" <r:@R> => {
+        Box::new(ast::ExprAST::UnaryOp(ast::UnaryOpcode::UtilFloor, e, l..r))
+    },
+    <e:Expr> <l:@L> ".round" <r:@R> => {
+        Box::new(ast::ExprAST::UnaryOp(ast::UnaryOpcode::UtilRound, e, l..r))
+    },
+    <e:Expr> <l:@L> ".abs" <r:@R> => {
+        Box::new(ast::ExprAST::UnaryOp(ast::UnaryOpcode::UtilAbs, e, l..r))
+    },
+    <e:Expr> <l:@L> ".ord" <r:@R> => {
+        Box::new(ast::ExprAST::UnaryOp(ast::UnaryOpcode::UtilOrd, e, l..r))
+    },
+    <e:Expr> <l:@L> ".chr" <r:@R> => {
+        Box::new(ast::ExprAST::UnaryOp(ast::UnaryOpcode::UtilChr, e, l..r))
+    },
+    <e:Expr> <l:@L> ".len" <r:@R> => {
+        Box::new(ast::ExprAST::UnaryOp(ast::UnaryOpcode::UtilLen, e, l..r))
     },
 
     #[precedence(level="2")] #[assoc(side="left")]
@@ -337,6 +367,16 @@ extern {
         ":str" => Token::AsStr,
         ":bool" => Token::AsBool,
         ":symbol" => Token::AsSymbol,
+        ".int" => Token::ToInt,
+        ".double" => Token::ToDouble,
+        ".str" => Token::ToString,
+        ".ceil" => Token::UtilCeil,
+        ".floor" => Token::UtilFloor,
+        ".round" => Token::UtilRound,
+        ".abs" => Token::UtilAbs,
+        ".ord" => Token::UtilOrd,
+        ".chr" => Token::UtilChr,
+        ".len" => Token::UtilLen,
         "." => Token::Dot,
         "," => Token::Comma,
         "@debug" => Token::AtDebug,

--- a/src/shol.lalrpop
+++ b/src/shol.lalrpop
@@ -207,6 +207,9 @@ Expr: Box<ast::ExprAST> = {
     <e:Expr> <l:@L> ".len" <r:@R> => {
         Box::new(ast::ExprAST::UnaryOp(ast::UnaryOpcode::UtilLen, e, l..r))
     },
+    <e:Expr> <l:@L> "[" <index:TopLevelExpr> "]" <r:@R> => {
+        Box::new(ast::ExprAST::BinaryOp(e, ast::Opcode::Nth, index, l..r))
+    },
     <e:Expr> <l:@L> "[" <start:TopLevelExpr?> ":" <end:TopLevelExpr?> "]" <r:@R> => {
         Box::new(ast::ExprAST::Slice(e, start, end, None, l..r))
     },

--- a/src/shol.lalrpop
+++ b/src/shol.lalrpop
@@ -207,6 +207,12 @@ Expr: Box<ast::ExprAST> = {
     <e:Expr> <l:@L> ".len" <r:@R> => {
         Box::new(ast::ExprAST::UnaryOp(ast::UnaryOpcode::UtilLen, e, l..r))
     },
+    <e:Expr> <l:@L> "[" <start:TopLevelExpr?> ":" <end:TopLevelExpr?> "]" <r:@R> => {
+        Box::new(ast::ExprAST::Slice(e, start, end, None, l..r))
+    },
+    <e:Expr> <l:@L> "[" <start:TopLevelExpr?> ":" <end:TopLevelExpr?> ":" <step:TopLevelExpr?> "]" <r:@R> => {
+        Box::new(ast::ExprAST::Slice(e, start, end, step, l..r))
+    },
 
     #[precedence(level="4")] #[assoc(side="left")]
     <lhs:Expr> <l:@L> "*" <r:@R> <rhs:Expr> => {
@@ -367,6 +373,7 @@ extern {
         "&&" => Token::LogicalAnd,
         "||" => Token::LogicalOr,
         "!" => Token::LogicalNot,
+        ":" => Token::Colon,
         ":int" => Token::AsInt,
         ":double" => Token::AsDouble,
         ":str" => Token::AsStr,

--- a/src/shol.lalrpop
+++ b/src/shol.lalrpop
@@ -148,7 +148,20 @@ OutputsEndsWithExpr: (Vec<ast::OutputAST>, Option<String>, Range<usize>) = {
 
 Expr: Box<ast::ExprAST> = {
     #[precedence(level="1")]
-    <Factor>,
+    <l:@L> <name:"$xx"> <r:@R> =>
+        Box::new(ast::ExprAST::Capture(name, l..r)),
+    "(" <TopLevelExpr> ")",
+    <l:@L> "-" <r:@R> <e:Expr> =>
+        Box::new(ast::ExprAST::UnaryOp(ast::UnaryOpcode::Neg, e, l..r)),
+    <l:@L> "!" <r:@R> <e:Expr> =>
+        Box::new(ast::ExprAST::UnaryOp(ast::UnaryOpcode::LogicalNot, e, l..r)),
+    <l:@L> "~" <r:@R> <e:Expr> =>
+        Box::new(ast::ExprAST::UnaryOp(ast::UnaryOpcode::BitNot, e, l..r)),
+
+    #[precedence(level="2")] // Literal の SignedInt を 単項演算子 `-` より優先
+    <Literal> => Box::new(<>),
+
+    #[precedence(level="3")]
     <e:Expr> <l:@L> ":int" <r:@R> => {
         Box::new(ast::ExprAST::UnaryOp(ast::UnaryOpcode::As(semantics::Type::Int), e, l..r))
     },
@@ -195,7 +208,7 @@ Expr: Box<ast::ExprAST> = {
         Box::new(ast::ExprAST::UnaryOp(ast::UnaryOpcode::UtilLen, e, l..r))
     },
 
-    #[precedence(level="2")] #[assoc(side="left")]
+    #[precedence(level="4")] #[assoc(side="left")]
     <lhs:Expr> <l:@L> "*" <r:@R> <rhs:Expr> => {
         Box::new(ast::ExprAST::BinaryOp(lhs, ast::Opcode::Mul, rhs, l..r))
     },
@@ -206,7 +219,7 @@ Expr: Box<ast::ExprAST> = {
         Box::new(ast::ExprAST::BinaryOp(lhs, ast::Opcode::Mod, rhs, l..r))
     },
 
-    #[precedence(level="3")] #[assoc(side="left")]
+    #[precedence(level="5")] #[assoc(side="left")]
     <lhs:Expr> <l:@L> "+" <r:@R> <rhs:Expr> => {
         Box::new(ast::ExprAST::BinaryOp(lhs, ast::Opcode::Add, rhs, l..r))
     },
@@ -214,7 +227,7 @@ Expr: Box<ast::ExprAST> = {
         Box::new(ast::ExprAST::BinaryOp(lhs, ast::Opcode::Sub, rhs, l..r))
     },
 
-    #[precedence(level="4")] #[assoc(side="left")]
+    #[precedence(level="6")] #[assoc(side="left")]
     <lhs:Expr> <l:@L> "<<" <r:@R> <rhs:Expr> => {
         Box::new(ast::ExprAST::BinaryOp(lhs, ast::Opcode::BitShiftLeft, rhs, l..r))
     },
@@ -222,7 +235,7 @@ Expr: Box<ast::ExprAST> = {
         Box::new(ast::ExprAST::BinaryOp(lhs, ast::Opcode::BitShiftRight, rhs, l..r))
     },
 
-    #[precedence(level="5")] #[assoc(side="left")]
+    #[precedence(level="7")] #[assoc(side="left")]
     <lhs:Expr> <l:@L> "=" <r:@R> <rhs:Expr> => {
         Box::new(ast::ExprAST::BinaryOp(lhs, ast::Opcode::Eq, rhs, l..r))
     },
@@ -242,47 +255,33 @@ Expr: Box<ast::ExprAST> = {
         Box::new(ast::ExprAST::BinaryOp(lhs, ast::Opcode::Ge, rhs, l..r))
     },
 
-    #[precedence(level="6")] #[assoc(side="left")]
+    #[precedence(level="8")] #[assoc(side="left")]
     <lhs:Expr> <l:@L> "&" <r:@R> <rhs:Expr> => {
         Box::new(ast::ExprAST::BinaryOp(lhs, ast::Opcode::BitAnd, rhs, l..r))
     },
 
-    #[precedence(level="7")] #[assoc(side="left")]
+    #[precedence(level="9")] #[assoc(side="left")]
     <lhs:Expr> <l:@L> "^" <r:@R> <rhs:Expr> => {
         Box::new(ast::ExprAST::BinaryOp(lhs, ast::Opcode::BitXor, rhs, l..r))
     },
 
-    #[precedence(level="8")] #[assoc(side="left")]
+    #[precedence(level="10")] #[assoc(side="left")]
     <lhs:Expr> <l:@L> "|" <r:@R> <rhs:Expr> => {
         Box::new(ast::ExprAST::BinaryOp(lhs, ast::Opcode::BitOr, rhs, l..r))
     },
 
-    #[precedence(level="9")] #[assoc(side="left")]
+    #[precedence(level="11")] #[assoc(side="left")]
     <lhs:Expr> <l:@L> "&&" <r:@R> <rhs:Expr> => {
         Box::new(ast::ExprAST::BinaryOp(lhs, ast::Opcode::LogicalAnd, rhs, l..r))
     },
 
-    #[precedence(level="10")] #[assoc(side="left")]
+    #[precedence(level="12")] #[assoc(side="left")]
     <lhs:Expr> <l:@L> "||" <r:@R> <rhs:Expr> => {
         Box::new(ast::ExprAST::BinaryOp(lhs, ast::Opcode::LogicalOr, rhs, l..r))
     },
 }
 
-Factor: Box<ast::ExprAST> = {
-    #[precedence(level="1")]
-    <l:@L> <name:"$xx"> <r:@R> =>
-        Box::new(ast::ExprAST::Capture(name, l..r)),
-    "(" <Expr> ")",
-    <l:@L> "-" <r:@R> <e:Factor> =>
-        Box::new(ast::ExprAST::UnaryOp(ast::UnaryOpcode::Neg, e, l..r)),
-    <l:@L> "!" <r:@R> <e:Factor> =>
-        Box::new(ast::ExprAST::UnaryOp(ast::UnaryOpcode::LogicalNot, e, l..r)),
-    <l:@L> "~" <r:@R> <e:Factor> =>
-        Box::new(ast::ExprAST::UnaryOp(ast::UnaryOpcode::BitNot, e, l..r)),
-
-    #[precedence(level="2")]
-    <Literal> => Box::new(<>),
-}
+// MARK: リテラル
 
 Literal: ast::ExprAST = {
     <SignedInt> =>
@@ -321,6 +320,12 @@ CommaListing<T>: Vec<T> = {
         v.push(e);
         v
     }
+}
+
+// Expr の内部から #[precedence(level)] 最高レベルにアクセスするために使用
+// Lalrpop の仕様上, 自分より高いレベルの生成規則に直接アクセスすることはできないため
+TopLevelExpr: Box<ast::ExprAST> = {
+    <Expr>,
 }
 
 // MARK: トークン (終端記号)

--- a/src/tokens.rs
+++ b/src/tokens.rs
@@ -94,7 +94,7 @@ pub enum Token {
     #[token("false")]
     False,
 
-    // 式に使われる記号
+    // 括弧類
     #[token("(")]
     LParen,
     #[token(")")]
@@ -103,6 +103,8 @@ pub enum Token {
     LBracket,
     #[token("]")]
     RBracket,
+
+    // 比較演算子
     #[token("=")]
     Equal,
     #[token("!=")]
@@ -115,6 +117,8 @@ pub enum Token {
     LessEqual,
     #[token(">=")]
     GreaterEqual,
+
+    // 算術演算子
     #[token("+")]
     Add,
     #[token("-")]
@@ -125,6 +129,8 @@ pub enum Token {
     Div,
     #[token("%")]
     Mod,
+
+    // ビット演算子
     #[token("&")]
     Ampersand,
     #[token("|")]
@@ -137,12 +143,16 @@ pub enum Token {
     BitShiftRight,
     #[token("<<")]
     BitShiftLeft,
+
+    // 論理演算子
     #[token("&&")]
     LogicalAnd,
     #[token("||")]
     LogicalOr,
     #[token("!")]
     LogicalNot,
+
+    // 型ヒント演算子
     #[token(":int")]
     AsInt,
     #[token(":double")]
@@ -153,6 +163,30 @@ pub enum Token {
     AsBool,
     #[token(":symbol")]
     AsSymbol,
+
+    // 型変換
+    #[token(".int")]
+    ToInt,
+    #[token(".double")]
+    ToDouble,
+    #[token(".str")]
+    ToString,
+
+    // ユーティリティ演算子
+    #[token(".ceil")]
+    UtilCeil,
+    #[token(".floor")]
+    UtilFloor,
+    #[token(".round")]
+    UtilRound,
+    #[token(".abs")]
+    UtilAbs,
+    #[token(".ord")]
+    UtilOrd,
+    #[token(".chr")]
+    UtilChr,
+    #[token(".len")]
+    UtilLen,
 
     // 構文に使われる記号
     #[token(".")]

--- a/src/tokens.rs
+++ b/src/tokens.rs
@@ -157,23 +157,23 @@ pub enum Token {
     Colon,
 
     // 型ヒント演算子
-    #[token(":int")]
+    #[regex(r":i(nt)?")]
     AsInt,
-    #[token(":double")]
+    #[regex(r":d(ouble)?")]
     AsDouble,
-    #[token(":str")]
+    #[regex(r":s(tr)?")]
     AsStr,
-    #[token(":bool")]
+    #[regex(r":b(ool)?")]
     AsBool,
-    #[token(":symbol")]
+    #[regex(r":sym(bol)?")]
     AsSymbol,
 
     // 型変換
-    #[token(".int")]
+    #[regex(r"\.i(nt)?")]
     ToInt,
-    #[token(".double")]
+    #[regex(r"\.d(ouble)?")]
     ToDouble,
-    #[token(".str")]
+    #[regex(r"\.s(tr)?")]
     ToString,
 
     // ユーティリティ演算子

--- a/src/tokens.rs
+++ b/src/tokens.rs
@@ -152,6 +152,10 @@ pub enum Token {
     #[token("!")]
     LogicalNot,
 
+    // 文字列スライス
+    #[token(":")]
+    Colon,
+
     // 型ヒント演算子
     #[token(":int")]
     AsInt,


### PR DESCRIPTION
close #54

## 型ヒント演算子
- `:i` ... `:int` と等価
- `:d` ... `:double` と等価
- `:s` ... `:str` と等価
- `:b` ... `:bool` と等価
- `:sym` ... `:symbol` と等価

## 型変換演算子
- `.i`, `.int` ... 他の型の値を `int` に変換
- `.d`, `.double` ... 他の型の値を `double` に変換
- `.s`, `.str` ... 他の型の値を `str` に変換

## ユーティリティ関数
- `.ceil` ... 天井関数 (double -> int)
- `.floor` ... 床関数 (double -> int)
- `.round` ... 四捨五入 (double -> int)
- `.abs` ... 絶対値 (int -> int, double -> double)
- `.ord` ... 先頭文字の文字コード (str -> int) ※変換失敗時は 0
- `.chr` ... 文字コードから文字 (int -> str) ※変換失敗時は ""
- `.len` ... 文字数 (str -> int)

## スライス演算
Python と完全に同じ仕様で実装しました。

- `$[1]` ... `$` の 2 文字目
- `$[-2]` ... `$` の最後から 2 文字目
- `$[1:-1]` ... `$` の最初と最後の 1 文字を取り除いたもの
- `$[:6:2]` ... `$` の 1, 3, 5 文字目を並べたもの
- `$[::-1]` ... `$` の反転