### PR TITLE
Fix: 出力式のない出力先も未定義コロニーをチェックしてエラーを出すようにした

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -104,6 +104,11 @@ pub struct RuleSetAST {
 pub struct RuleAST {
     pub conditions: Vec<ConditionAST>,
     pub outputs: Vec<OutputAST>,
+    /// 出力先コロニーの名前
+    pub destination: Option<String>,
+    /// プログラム中の #xx の位置
+    pub destination_location: Range<usize>,
+    /// 意味解析で追加されるメタデータ
     pub meta: Option<semantics::RuleASTMeta>,
 }
 
@@ -140,8 +145,6 @@ pub struct OutputAST {
     pub expr: ExprAST,
     /// 出力先コロニーの名前
     pub destination: Option<String>,
-    /// プログラム中の #xx の位置
-    pub destination_location: Range<usize>,
     /// 意味解析で追加されるメタデータ
     pub meta: Option<semantics::OutputASTMeta>,
 }

--- a/src/shol.lalrpop
+++ b/src/shol.lalrpop
@@ -75,7 +75,9 @@ Rule: ast::RuleAST = {
     <conds:Conditions> <outs:Outputs> => {
         ast::RuleAST {
             conditions: conds,
-            outputs: outs,
+            outputs: outs.0,
+            destination: outs.1,
+            destination_location: outs.2,
             meta: None,
         }
     },
@@ -116,9 +118,9 @@ Condition: ast::ConditionAST = {
     },
 }
 
-Outputs: Vec<ast::OutputAST> = {
-    <OutputsEndsWithDest> => <>.0,
-    <OutputsEndsWithExpr> => <>.0,
+Outputs: (Vec<ast::OutputAST>, Option<String>, Range<usize>) = {
+    <OutputsEndsWithDest>,
+    <OutputsEndsWithExpr>,
 }
 OutputsEndsWithDest: (Vec<ast::OutputAST>, Option<String>, Range<usize>) = {
     <l:@L> <dest:"#xx"> <r:@R> => (vec![], dest, l..r),
@@ -128,7 +130,6 @@ OutputsEndsWithExpr: (Vec<ast::OutputAST>, Option<String>, Range<usize>) = {
         vd.0.push(ast::OutputAST {
             expr: *expr,
             destination: vd.1.clone(),
-            destination_location: vd.2.clone(),
             meta: None,
         });
         vd
@@ -137,7 +138,6 @@ OutputsEndsWithExpr: (Vec<ast::OutputAST>, Option<String>, Range<usize>) = {
         vd.0.push(ast::OutputAST {
             expr: *expr,
             destination: vd.1.clone(),
-            destination_location: vd.2.clone(),
             meta: None,
         });
         vd


### PR DESCRIPTION
close #65 