### PR TITLE
Feature: リテラルと単項演算子についての文法の癖を修正

### DIFF
--- a/src/shol.lalrpop
+++ b/src/shol.lalrpop
@@ -146,8 +146,18 @@ OutputsEndsWithExpr: (Vec<ast::OutputAST>, Option<String>, Range<usize>) = {
 
 // MARK: 式
 
+// `-` のつかないリテラルの直前には `-` 以外の単項演算子を許容
+PositiveLiteralWithPreUnary: Box<ast::ExprAST> = {
+    <l:@L> "!" <r:@R> <e:PositiveLiteral> =>
+        Box::new(ast::ExprAST::UnaryOp(ast::UnaryOpcode::LogicalNot, Box::new(e), l..r)),
+    <l:@L> "~" <r:@R> <e:PositiveLiteral> =>
+        Box::new(ast::ExprAST::UnaryOp(ast::UnaryOpcode::BitNot, Box::new(e), l..r)),
+}
+
 Expr: Box<ast::ExprAST> = {
     #[precedence(level="1")]
+    <NonPositiveLiteral> => Box::new(<>),
+    <PositiveLiteralWithPreUnary>,
     <l:@L> <name:"$xx"> <r:@R> =>
         Box::new(ast::ExprAST::Capture(name, l..r)),
     "(" <TopLevelExpr> ")",
@@ -158,8 +168,8 @@ Expr: Box<ast::ExprAST> = {
     <l:@L> "~" <r:@R> <e:Expr> =>
         Box::new(ast::ExprAST::UnaryOp(ast::UnaryOpcode::BitNot, e, l..r)),
 
-    #[precedence(level="2")] // Literal の SignedInt を 単項演算子 `-` より優先
-    <Literal> => Box::new(<>),
+    #[precedence(level="2")]
+    <PositiveLiteral> => Box::new(<>),
 
     #[precedence(level="3")]
     <e:Expr> <l:@L> ":int" <r:@R> => {
@@ -293,10 +303,31 @@ Expr: Box<ast::ExprAST> = {
 // MARK: リテラル
 
 Literal: ast::ExprAST = {
-    <SignedInt> =>
+    <NonPositiveLiteral>,
+    <PositiveLiteral>,
+}
+
+// 直前に `-` をつけたら負のリテラルになるもの
+PositiveLiteral: ast::ExprAST = {
+    <"int"> =>
         ast::ExprAST::Number(<>),
-    <SignedDouble> =>
+    <"double"> =>
         ast::ExprAST::Double(<>),
+    <"int"> "." =>
+        ast::ExprAST::Double(<> as f64),
+}
+
+NonPositiveLiteral: ast::ExprAST = {
+    "-" <"int"> =>
+        ast::ExprAST::Number(-<>),
+    <"intmin"> =>
+        ast::ExprAST::Number(<>),
+    "-" <"double"> =>
+        ast::ExprAST::Double(-<>),
+    "-" <"int"> "." =>
+        ast::ExprAST::Double(-<> as f64),
+    <"intmin"> "." =>
+        ast::ExprAST::Double(<> as f64),
     "identf" =>
         ast::ExprAST::Str(<>),
     "str" =>
@@ -307,18 +338,6 @@ Literal: ast::ExprAST = {
         ast::ExprAST::Bool(true),
     "false" =>
         ast::ExprAST::Bool(false),
-}
-
-SignedInt: i32 = {
-    <"int">,
-    "-" <"int"> => -<>,
-    <"intmin">,
-}
-
-SignedDouble: f64 = {
-    <"double">,
-    "-" <"double"> => -<>,
-    <SignedInt> "." => <> as f64
 }
 
 // MARK: ヘルパー非終端記号

--- a/src/shol.lalrpop
+++ b/src/shol.lalrpop
@@ -310,14 +310,15 @@ Literal: ast::ExprAST = {
 }
 
 SignedInt: i32 = {
-    <n:"int"> => n,
-    "-" <n:"int"> => -n,
+    <"int">,
+    "-" <"int"> => -<>,
     <"intmin">,
 }
 
 SignedDouble: f64 = {
-    <n:"double"> => n,
-    "-" <n:"double"> => -n,
+    <"double">,
+    "-" <"double"> => -<>,
+    <SignedInt> "." => <> as f64
 }
 
 // MARK: ヘルパー非終端記号

--- a/src/tokens.rs
+++ b/src/tokens.rs
@@ -73,7 +73,8 @@ impl From<ParseFloatError> for LexicalError {
 #[logos(skip r"//.*")]
 #[logos(subpattern fractional = r"[0-9]+\.|[0-9]*\.[0-9]+")]
 #[logos(subpattern exponent = r"[eE][+-]?[0-9]+")]
-#[logos(subpattern double_literal = r"(?&fractional)(?&exponent)?|[0-9]+(?&exponent)")]
+// r"[0-9]+\." の表記は `5.abs` を `5.`, `abs` にしてしまうので, 文法の方で処理
+#[logos(subpattern double_literal = r"[0-9]*\.[0-9]+|(?&fractional)(?&exponent)|[0-9]+(?&exponent)")]
 pub enum Token {
     // 識別子とリテラル
     #[regex(r"(\p{XID_Start}|_)\p{XID_Continue}*", |lex| lex.slice().to_string())]


### PR DESCRIPTION
close #80 

今までの文法では

- `3.abs` が double 型リテラル `3.`, 識別子 `abs` として解析されてしまう
- `~$` は許容するが `~1` は許容しない（`~(1)` と書く必要がある）

 など、リテラルと単項演算子に関して細かい制約のあるあまり直感的でない文法になっていたので、それを修正した。

- `3.abs` は int 型リテラル `3`, 後置単項演算子 `.abs` として解析
- リテラルに前置単項演算子をつけるのを許容 (`~-1`, `~-1`, `--1`, `!true` など)