### PR TITLE
Feature: ビルドのワークフローを追加

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,9 +11,10 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-rust@v2
+      - uses: actions-rs/toolchain@v1
         with:
-          rust-version: stable
+          toolchain: stable
+          override: true
       - run: cargo build --release
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,13 +10,22 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
           override: true
       - run: cargo build --release
+      - name: Prepare artifact path
+        id: prepare-path
+        shell: bash
+        run: |
+          if [ "${{ matrix.os }}" == "windows-latest" ]; then
+            echo "ARTIFACT_PATH=target/release/shol.exe" >> $GITHUB_ENV
+          else
+            echo "ARTIFACT_PATH=target/release/shol" >> $GITHUB_ENV
+          fi
       - uses: actions/upload-artifact@v4
         with:
           name: shol-${{ matrix.os }}
-          path: target/release/shol
+          path: ${{ env.ARTIFACT_PATH }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,21 @@
+name: Build
+on:
+  push:
+    tags:
+      - "v*"
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: rust-lang/setup-rust@v1
+        with:
+          rust-version: stable
+      - run: cargo build --release
+      - uses: actions/upload-artifact@v3
+        with:
+          name: shol-${{ matrix.os }}
+          path: target/release/shol

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,11 +11,11 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
       - uses: actions/checkout@v3
-      - uses: rust-lang/setup-rust@v1
+      - uses: actions/setup-rust@v2
         with:
           rust-version: stable
       - run: cargo build --release
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: shol-${{ matrix.os }}
           path: target/release/shol


### PR DESCRIPTION
`v1.0.0` のように v から始まるタグを追加すると Build というワークフローが走ります。

コンパイラを Windows 版・Mac 版・Ubuntu 版 をビルドしてアーティファクトとして出力します。

アーティファクトは、[Actions](https://github.com/Se1getsu/shol/actions) からそのアクションのページを開いて一番下にスクロールするとあります。